### PR TITLE
feat(python): add capacity monitoring module and improve client encapsulation

### DIFF
--- a/python/examples/print_heimdall_dlr.py
+++ b/python/examples/print_heimdall_dlr.py
@@ -1,0 +1,34 @@
+import logging
+from heimdall_api_client.client import HeimdallApiClient
+
+logging.basicConfig(level=logging.INFO)
+
+client = HeimdallApiClient(
+    client_id="your_client_id",
+    client_secret="your_client_secret",
+)
+
+assets = client.get_assets()
+grid_owner = assets.data.grid_owners[0]
+
+print(f"\nGrid Owner: {grid_owner.name}\n")
+
+for facility in grid_owner.facilities:
+    line = facility.line
+    if not line:
+        print(f"Facility: {facility.name} has no lines.\n")
+        continue
+    try:
+        dlr_response = client.get_latest_heimdall_dlr(line_id=line.id)
+        dlr = dlr_response.data.dlr
+        dlr_forecast_response = client.get_latest_heimdall_dlr_forecasts(line_id=line.id)
+        dlr_forecast = dlr_forecast_response.data.dlr_forecasts
+        print(f"Facility: {facility.name}")
+        print(f"  Line: {line.name} (ID: {line.id})\n")
+        print(f"    {dlr_response.data.metric}, timestamp {dlr.timestamp}\n")
+        print(f"        {dlr.value} {dlr_response.data.unit}\n")
+        print(f"    {dlr_forecast_response.data.metric}, updated at {dlr_forecast_response.data.updated_timestamp}:")
+        for forecast in dlr_forecast:
+            print(f"      {forecast.timestamp}: {forecast.prediction.value} {dlr_forecast_response.data.unit}")
+    except Exception as e:
+        print(f"  Failed to fetch DLR for line '{line.name}' (ID: {line.id}): {e}\n")

--- a/python/heimdall_api_client/__init__.py
+++ b/python/heimdall_api_client/__init__.py
@@ -1,0 +1,3 @@
+from .client import HeimdallApiClient
+
+__all__ = ["HeimdallApiClient"]

--- a/python/heimdall_api_client/assets.py
+++ b/python/heimdall_api_client/assets.py
@@ -1,0 +1,9 @@
+from heimdall_api_client.assets_api_client.api.assets import assets_v1_get_assets
+from heimdall_api_client.assets_api_client.client import AuthenticatedClient
+
+
+def get_assets(client: AuthenticatedClient, x_region: str):
+    response = assets_v1_get_assets.sync_detailed(client=client, x_region=x_region)
+    if response.status_code != 200:
+        raise Exception(f"Error fetching assets: {response.status_code} {response.text}")
+    return response.parsed

--- a/python/heimdall_api_client/capacity_monitoring.py
+++ b/python/heimdall_api_client/capacity_monitoring.py
@@ -1,0 +1,32 @@
+from uuid import UUID
+from heimdall_api_client.assets_api_client.client import AuthenticatedClient
+from heimdall_api_client.capacity_monitoring_api_client.api.line import (
+    capacity_monitoring_v1_lines_get_latest_heimdall_dlr as get_latest_dlr,
+    capacity_monitoring_v1_lines_get_latest_heimdall_aar as get_latest_aar,
+    capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts as get_latest_dlr_forecasts,
+    capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts as get_latest_aar_forecasts,
+)
+
+def get_latest_heimdall_dlr(client: AuthenticatedClient, line_id: UUID, region: str):
+        response = get_latest_dlr.sync_detailed(client=client, line_id=line_id, x_region=region)
+        if response.status_code != 200:
+            raise Exception(f"Error fetching latest Heimdall DLR: {response.status_code} {response.text}")
+        return response.parsed
+
+def get_latest_heimdall_aar(client: AuthenticatedClient, line_id: UUID, region: str):
+    response = get_latest_aar.sync_detailed(client=client, line_id=line_id, x_region=region)
+    if response.status_code != 200:
+        raise Exception(f"Error fetching latest Heimdall AAR: {response.status_code} {response.text}")
+    return response.parsed
+
+def get_latest_heimdall_dlr_forecasts(client: AuthenticatedClient, line_id: UUID, region: str):
+    response = get_latest_dlr_forecasts.sync_detailed(client=client, line_id=line_id, x_region=region)
+    if response.status_code != 200:
+        raise Exception(f"Error fetching latest Heimdall DLR forecasts: {response.status_code} {response.text}")
+    return response.parsed
+
+def get_latest_heimdall_arr_forecasts(client: AuthenticatedClient, line_id: UUID, region: str):
+    response = get_latest_aar_forecasts.sync_detailed(client=client, line_id=line_id, x_region=region)
+    if response.status_code != 200:
+        raise Exception(f"Error fetching latest Heimdall AAR forecasts: {response.status_code} {response.text}")
+    return response.parsed

--- a/python/heimdall_api_client/capacity_monitoring_api_client/__init__.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/__init__.py
@@ -1,0 +1,8 @@
+
+""" A client library for accessing Capacity Monitoring API """
+from .client import AuthenticatedClient, Client
+
+__all__ = (
+    "AuthenticatedClient",
+    "Client",
+)

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/__init__.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/__init__.py
@@ -1,0 +1,1 @@
+""" Contains methods for accessing the API """

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/facility/__init__.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/facility/__init__.py
@@ -1,0 +1,1 @@
+""" Contains endpoint functions for accessing the API """

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/facility/capacity_monitoring_v1_facilities_get_latest_circuit_rating.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/facility/capacity_monitoring_v1_facilities_get_latest_circuit_rating.py
@@ -1,0 +1,279 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.capacity_monitoring_v1_facilities_get_latest_circuit_rating_response_200 import CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200
+from ...models.capacity_monitoring_v1_facilities_get_latest_circuit_rating_x_region import CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion
+from ...models.problem_details import ProblemDetails
+from ...types import UNSET, Unset
+from typing import cast
+from typing import Union
+from uuid import UUID
+
+
+
+def _get_kwargs(
+    facility_id: UUID,
+    *,
+    x_region: Union[Unset, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion] = CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion.EU,
+
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_region, Unset):
+        headers["x-region"] = str(x_region)
+
+
+
+
+    
+
+    
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/capacity_monitoring/v1/facilities/{facility_id}/circuit_ratings/latest".format(facility_id=facility_id,),
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200, ProblemDetails]]:
+    if response.status_code == 200:
+        response_200 = CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = ProblemDetails.from_dict(response.json())
+
+
+
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 500:
+        response_500 = ProblemDetails.from_dict(response.json())
+
+
+
+        return response_500
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200, ProblemDetails]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    facility_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion] = CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion.EU,
+
+) -> Response[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200, ProblemDetails]]:
+    """ Get latest circuit rating
+
+     This endpoint returns the most recent circuit rating for the facility.
+
+    The circuit rating is defined as the lowest of:
+      - Heimdall DLR
+      - The facility's upper limit
+      - The lowest steady-state rating among all facility components
+
+    The upper limit can be either:
+      - A fixed value
+      - A percentage of the line's steady-state rating
+
+    Note: The circuit rating is the only rating provided by the Heimdall Power API that is not a line
+    rating.
+      It reflects the facility's constraints and does not represent the capacity of the line itself. Use
+    a line rating method to obtain that.
+
+    Args:
+        facility_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion]):
+            Default: CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200, ProblemDetails]]
+     """
+
+
+    kwargs = _get_kwargs(
+        facility_id=facility_id,
+x_region=x_region,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    facility_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion] = CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion.EU,
+
+) -> Optional[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200, ProblemDetails]]:
+    """ Get latest circuit rating
+
+     This endpoint returns the most recent circuit rating for the facility.
+
+    The circuit rating is defined as the lowest of:
+      - Heimdall DLR
+      - The facility's upper limit
+      - The lowest steady-state rating among all facility components
+
+    The upper limit can be either:
+      - A fixed value
+      - A percentage of the line's steady-state rating
+
+    Note: The circuit rating is the only rating provided by the Heimdall Power API that is not a line
+    rating.
+      It reflects the facility's constraints and does not represent the capacity of the line itself. Use
+    a line rating method to obtain that.
+
+    Args:
+        facility_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion]):
+            Default: CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200, ProblemDetails]
+     """
+
+
+    return sync_detailed(
+        facility_id=facility_id,
+client=client,
+x_region=x_region,
+
+    ).parsed
+
+async def asyncio_detailed(
+    facility_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion] = CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion.EU,
+
+) -> Response[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200, ProblemDetails]]:
+    """ Get latest circuit rating
+
+     This endpoint returns the most recent circuit rating for the facility.
+
+    The circuit rating is defined as the lowest of:
+      - Heimdall DLR
+      - The facility's upper limit
+      - The lowest steady-state rating among all facility components
+
+    The upper limit can be either:
+      - A fixed value
+      - A percentage of the line's steady-state rating
+
+    Note: The circuit rating is the only rating provided by the Heimdall Power API that is not a line
+    rating.
+      It reflects the facility's constraints and does not represent the capacity of the line itself. Use
+    a line rating method to obtain that.
+
+    Args:
+        facility_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion]):
+            Default: CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200, ProblemDetails]]
+     """
+
+
+    kwargs = _get_kwargs(
+        facility_id=facility_id,
+x_region=x_region,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    facility_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion] = CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion.EU,
+
+) -> Optional[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200, ProblemDetails]]:
+    """ Get latest circuit rating
+
+     This endpoint returns the most recent circuit rating for the facility.
+
+    The circuit rating is defined as the lowest of:
+      - Heimdall DLR
+      - The facility's upper limit
+      - The lowest steady-state rating among all facility components
+
+    The upper limit can be either:
+      - A fixed value
+      - A percentage of the line's steady-state rating
+
+    Note: The circuit rating is the only rating provided by the Heimdall Power API that is not a line
+    rating.
+      It reflects the facility's constraints and does not represent the capacity of the line itself. Use
+    a line rating method to obtain that.
+
+    Args:
+        facility_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion]):
+            Default: CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200, ProblemDetails]
+     """
+
+
+    return (await asyncio_detailed(
+        facility_id=facility_id,
+client=client,
+x_region=x_region,
+
+    )).parsed

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/facility/capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/facility/capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts.py
@@ -1,0 +1,307 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_response_200 import CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200
+from ...models.capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_x_region import CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion
+from ...models.problem_details import ProblemDetails
+from ...types import UNSET, Unset
+from typing import cast
+from typing import Union
+from uuid import UUID
+
+
+
+def _get_kwargs(
+    facility_id: UUID,
+    *,
+    x_region: Union[Unset, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion] = CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion.EU,
+
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_region, Unset):
+        headers["x-region"] = str(x_region)
+
+
+
+
+    
+
+    
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/capacity_monitoring/v1/facilities/{facility_id}/circuit_ratings/forecasts".format(facility_id=facility_id,),
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200, ProblemDetails]]:
+    if response.status_code == 200:
+        response_200 = CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = ProblemDetails.from_dict(response.json())
+
+
+
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 500:
+        response_500 = ProblemDetails.from_dict(response.json())
+
+
+
+        return response_500
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200, ProblemDetails]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    facility_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion] = CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion.EU,
+
+) -> Response[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200, ProblemDetails]]:
+    """ Get latest circuit rating forecasts
+
+     This endpoint returns the most recent circuit rating forecasts for the facility.
+
+    The forecasted hours returned by the endpoint are set to 72 hours, and are provided in 1-hour
+    intervals.
+
+    The response contains a series of buckets, each with a timestamp and predictions based on different
+    values of confidence levels `p80`, `p90`, `p95` and `p99`.
+
+    The circuit rating forecast is defined as the Heimdall DLR forecast limited by the facility
+    component steady state ratings and the upper limit, similar to the real time
+    circuit rating.
+
+    To calculate the upper limit, we use the Steady State Line Ratings, as they also contain forecasted
+    values.
+
+    The upper limit can be either:
+      - A fixed value
+      - A percentage of the line's steady-state rating
+
+    If the predictions contains no facility component id, then the dimensioning component is the line
+    itself.
+
+    Args:
+        facility_id (UUID):
+        x_region (Union[Unset,
+            CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion]):  Default:
+            CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200, ProblemDetails]]
+     """
+
+
+    kwargs = _get_kwargs(
+        facility_id=facility_id,
+x_region=x_region,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    facility_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion] = CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion.EU,
+
+) -> Optional[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200, ProblemDetails]]:
+    """ Get latest circuit rating forecasts
+
+     This endpoint returns the most recent circuit rating forecasts for the facility.
+
+    The forecasted hours returned by the endpoint are set to 72 hours, and are provided in 1-hour
+    intervals.
+
+    The response contains a series of buckets, each with a timestamp and predictions based on different
+    values of confidence levels `p80`, `p90`, `p95` and `p99`.
+
+    The circuit rating forecast is defined as the Heimdall DLR forecast limited by the facility
+    component steady state ratings and the upper limit, similar to the real time
+    circuit rating.
+
+    To calculate the upper limit, we use the Steady State Line Ratings, as they also contain forecasted
+    values.
+
+    The upper limit can be either:
+      - A fixed value
+      - A percentage of the line's steady-state rating
+
+    If the predictions contains no facility component id, then the dimensioning component is the line
+    itself.
+
+    Args:
+        facility_id (UUID):
+        x_region (Union[Unset,
+            CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion]):  Default:
+            CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200, ProblemDetails]
+     """
+
+
+    return sync_detailed(
+        facility_id=facility_id,
+client=client,
+x_region=x_region,
+
+    ).parsed
+
+async def asyncio_detailed(
+    facility_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion] = CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion.EU,
+
+) -> Response[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200, ProblemDetails]]:
+    """ Get latest circuit rating forecasts
+
+     This endpoint returns the most recent circuit rating forecasts for the facility.
+
+    The forecasted hours returned by the endpoint are set to 72 hours, and are provided in 1-hour
+    intervals.
+
+    The response contains a series of buckets, each with a timestamp and predictions based on different
+    values of confidence levels `p80`, `p90`, `p95` and `p99`.
+
+    The circuit rating forecast is defined as the Heimdall DLR forecast limited by the facility
+    component steady state ratings and the upper limit, similar to the real time
+    circuit rating.
+
+    To calculate the upper limit, we use the Steady State Line Ratings, as they also contain forecasted
+    values.
+
+    The upper limit can be either:
+      - A fixed value
+      - A percentage of the line's steady-state rating
+
+    If the predictions contains no facility component id, then the dimensioning component is the line
+    itself.
+
+    Args:
+        facility_id (UUID):
+        x_region (Union[Unset,
+            CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion]):  Default:
+            CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200, ProblemDetails]]
+     """
+
+
+    kwargs = _get_kwargs(
+        facility_id=facility_id,
+x_region=x_region,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    facility_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion] = CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion.EU,
+
+) -> Optional[Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200, ProblemDetails]]:
+    """ Get latest circuit rating forecasts
+
+     This endpoint returns the most recent circuit rating forecasts for the facility.
+
+    The forecasted hours returned by the endpoint are set to 72 hours, and are provided in 1-hour
+    intervals.
+
+    The response contains a series of buckets, each with a timestamp and predictions based on different
+    values of confidence levels `p80`, `p90`, `p95` and `p99`.
+
+    The circuit rating forecast is defined as the Heimdall DLR forecast limited by the facility
+    component steady state ratings and the upper limit, similar to the real time
+    circuit rating.
+
+    To calculate the upper limit, we use the Steady State Line Ratings, as they also contain forecasted
+    values.
+
+    The upper limit can be either:
+      - A fixed value
+      - A percentage of the line's steady-state rating
+
+    If the predictions contains no facility component id, then the dimensioning component is the line
+    itself.
+
+    Args:
+        facility_id (UUID):
+        x_region (Union[Unset,
+            CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion]):  Default:
+            CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200, ProblemDetails]
+     """
+
+
+    return (await asyncio_detailed(
+        facility_id=facility_id,
+client=client,
+x_region=x_region,
+
+    )).parsed

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/line/__init__.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/line/__init__.py
@@ -1,0 +1,1 @@
+""" Contains endpoint functions for accessing the API """

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_aar.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_aar.py
@@ -1,0 +1,259 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_aar_response_200 import CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200
+from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_aar_x_region import CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion
+from ...models.problem_details import ProblemDetails
+from ...types import UNSET, Unset
+from typing import cast
+from typing import Union
+from uuid import UUID
+
+
+
+def _get_kwargs(
+    line_id: UUID,
+    *,
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion.EU,
+
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_region, Unset):
+        headers["x-region"] = str(x_region)
+
+
+
+
+    
+
+    
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/capacity_monitoring/v1/lines/{line_id}/heimdall_aars/latest".format(line_id=line_id,),
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200, ProblemDetails]]:
+    if response.status_code == 200:
+        response_200 = CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = ProblemDetails.from_dict(response.json())
+
+
+
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 500:
+        response_500 = ProblemDetails.from_dict(response.json())
+
+
+
+        return response_500
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200, ProblemDetails]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion.EU,
+
+) -> Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200, ProblemDetails]]:
+    """ Get latest Heimdall AAR
+
+     This endpoint returns the most recent Heimdall Ambient-Adjusted Rating (AAR) for the line.
+
+    Heimdall AAR is calculated according to the CIGRE TB-601 standard for thermal calculation for OHLs.
+    It is purely based on weather data from weather service providers.
+    In this method for rating, both wind speed, wind direction, and solar heating are set to static
+    values chosen by the customer.
+    Therefore, only the Ambient temperature will vary dynamically.
+
+    Heimdall AAR is aggregated over the entire line. Using a 5-minute sliding window, the minimum
+    ampacity are calculated for each window.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion]):  Default:
+            CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200, ProblemDetails]]
+     """
+
+
+    kwargs = _get_kwargs(
+        line_id=line_id,
+x_region=x_region,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion.EU,
+
+) -> Optional[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200, ProblemDetails]]:
+    """ Get latest Heimdall AAR
+
+     This endpoint returns the most recent Heimdall Ambient-Adjusted Rating (AAR) for the line.
+
+    Heimdall AAR is calculated according to the CIGRE TB-601 standard for thermal calculation for OHLs.
+    It is purely based on weather data from weather service providers.
+    In this method for rating, both wind speed, wind direction, and solar heating are set to static
+    values chosen by the customer.
+    Therefore, only the Ambient temperature will vary dynamically.
+
+    Heimdall AAR is aggregated over the entire line. Using a 5-minute sliding window, the minimum
+    ampacity are calculated for each window.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion]):  Default:
+            CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200, ProblemDetails]
+     """
+
+
+    return sync_detailed(
+        line_id=line_id,
+client=client,
+x_region=x_region,
+
+    ).parsed
+
+async def asyncio_detailed(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion.EU,
+
+) -> Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200, ProblemDetails]]:
+    """ Get latest Heimdall AAR
+
+     This endpoint returns the most recent Heimdall Ambient-Adjusted Rating (AAR) for the line.
+
+    Heimdall AAR is calculated according to the CIGRE TB-601 standard for thermal calculation for OHLs.
+    It is purely based on weather data from weather service providers.
+    In this method for rating, both wind speed, wind direction, and solar heating are set to static
+    values chosen by the customer.
+    Therefore, only the Ambient temperature will vary dynamically.
+
+    Heimdall AAR is aggregated over the entire line. Using a 5-minute sliding window, the minimum
+    ampacity are calculated for each window.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion]):  Default:
+            CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200, ProblemDetails]]
+     """
+
+
+    kwargs = _get_kwargs(
+        line_id=line_id,
+x_region=x_region,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion.EU,
+
+) -> Optional[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200, ProblemDetails]]:
+    """ Get latest Heimdall AAR
+
+     This endpoint returns the most recent Heimdall Ambient-Adjusted Rating (AAR) for the line.
+
+    Heimdall AAR is calculated according to the CIGRE TB-601 standard for thermal calculation for OHLs.
+    It is purely based on weather data from weather service providers.
+    In this method for rating, both wind speed, wind direction, and solar heating are set to static
+    values chosen by the customer.
+    Therefore, only the Ambient temperature will vary dynamically.
+
+    Heimdall AAR is aggregated over the entire line. Using a 5-minute sliding window, the minimum
+    ampacity are calculated for each window.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion]):  Default:
+            CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200, ProblemDetails]
+     """
+
+
+    return (await asyncio_detailed(
+        line_id=line_id,
+client=client,
+x_region=x_region,
+
+    )).parsed

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts.py
@@ -1,0 +1,259 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_response_200 import CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200
+from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_x_region import CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion
+from ...models.problem_details import ProblemDetails
+from ...types import UNSET, Unset
+from typing import cast
+from typing import Union
+from uuid import UUID
+
+
+
+def _get_kwargs(
+    line_id: UUID,
+    *,
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion.EU,
+
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_region, Unset):
+        headers["x-region"] = str(x_region)
+
+
+
+
+    
+
+    
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/capacity_monitoring/v1/lines/{line_id}/heimdall_aars/forecasts".format(line_id=line_id,),
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200, ProblemDetails]]:
+    if response.status_code == 200:
+        response_200 = CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = ProblemDetails.from_dict(response.json())
+
+
+
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 500:
+        response_500 = ProblemDetails.from_dict(response.json())
+
+
+
+        return response_500
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200, ProblemDetails]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion.EU,
+
+) -> Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200, ProblemDetails]]:
+    """ Get latest Heimdall AAR forecasts
+
+     This endpoint returns the most recent Heimdall Ambient-Adjusted Rating (AAR) forecasts for the line.
+
+    The forecasted hours returned by the endpoint are defined by the line’s `available_forecast_hours`
+    configuration, typically 72 or 240, and are provided in 1-hour intervals.
+
+    The response contains a series of buckets, each with a timestamp and predictions based on different
+    values of confidence levels `p80`, `p90`, `p95` and `p99`.
+
+    For each unique timestamp and confidence level, we pick the value from the span which has the lowest
+    ampacity value as this will be the dimensioning value for the line.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion]):
+            Default: CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200, ProblemDetails]]
+     """
+
+
+    kwargs = _get_kwargs(
+        line_id=line_id,
+x_region=x_region,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion.EU,
+
+) -> Optional[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200, ProblemDetails]]:
+    """ Get latest Heimdall AAR forecasts
+
+     This endpoint returns the most recent Heimdall Ambient-Adjusted Rating (AAR) forecasts for the line.
+
+    The forecasted hours returned by the endpoint are defined by the line’s `available_forecast_hours`
+    configuration, typically 72 or 240, and are provided in 1-hour intervals.
+
+    The response contains a series of buckets, each with a timestamp and predictions based on different
+    values of confidence levels `p80`, `p90`, `p95` and `p99`.
+
+    For each unique timestamp and confidence level, we pick the value from the span which has the lowest
+    ampacity value as this will be the dimensioning value for the line.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion]):
+            Default: CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200, ProblemDetails]
+     """
+
+
+    return sync_detailed(
+        line_id=line_id,
+client=client,
+x_region=x_region,
+
+    ).parsed
+
+async def asyncio_detailed(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion.EU,
+
+) -> Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200, ProblemDetails]]:
+    """ Get latest Heimdall AAR forecasts
+
+     This endpoint returns the most recent Heimdall Ambient-Adjusted Rating (AAR) forecasts for the line.
+
+    The forecasted hours returned by the endpoint are defined by the line’s `available_forecast_hours`
+    configuration, typically 72 or 240, and are provided in 1-hour intervals.
+
+    The response contains a series of buckets, each with a timestamp and predictions based on different
+    values of confidence levels `p80`, `p90`, `p95` and `p99`.
+
+    For each unique timestamp and confidence level, we pick the value from the span which has the lowest
+    ampacity value as this will be the dimensioning value for the line.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion]):
+            Default: CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200, ProblemDetails]]
+     """
+
+
+    kwargs = _get_kwargs(
+        line_id=line_id,
+x_region=x_region,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion.EU,
+
+) -> Optional[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200, ProblemDetails]]:
+    """ Get latest Heimdall AAR forecasts
+
+     This endpoint returns the most recent Heimdall Ambient-Adjusted Rating (AAR) forecasts for the line.
+
+    The forecasted hours returned by the endpoint are defined by the line’s `available_forecast_hours`
+    configuration, typically 72 or 240, and are provided in 1-hour intervals.
+
+    The response contains a series of buckets, each with a timestamp and predictions based on different
+    values of confidence levels `p80`, `p90`, `p95` and `p99`.
+
+    For each unique timestamp and confidence level, we pick the value from the span which has the lowest
+    ampacity value as this will be the dimensioning value for the line.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion]):
+            Default: CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200, ProblemDetails]
+     """
+
+
+    return (await asyncio_detailed(
+        line_id=line_id,
+client=client,
+x_region=x_region,
+
+    )).parsed

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_dlr.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_dlr.py
@@ -1,0 +1,255 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_dlr_response_200 import CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200
+from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_dlr_x_region import CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion
+from ...models.problem_details import ProblemDetails
+from ...types import UNSET, Unset
+from typing import cast
+from typing import Union
+from uuid import UUID
+
+
+
+def _get_kwargs(
+    line_id: UUID,
+    *,
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion.EU,
+
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_region, Unset):
+        headers["x-region"] = str(x_region)
+
+
+
+
+    
+
+    
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/capacity_monitoring/v1/lines/{line_id}/heimdall_dlrs/latest".format(line_id=line_id,),
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200, ProblemDetails]]:
+    if response.status_code == 200:
+        response_200 = CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = ProblemDetails.from_dict(response.json())
+
+
+
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 500:
+        response_500 = ProblemDetails.from_dict(response.json())
+
+
+
+        return response_500
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200, ProblemDetails]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion.EU,
+
+) -> Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200, ProblemDetails]]:
+    """ Get latest Heimdall DLR
+
+     This endpoint returns the most recent Heimdall Dynamic Line Rating (DLR) for the line.
+
+    Heimdall DLR is calculated according to our own proprietary method, based on the CIGRE TB-601
+    standard for thermal calculation for OHLs.
+    This method also takes the conductor temperature and current into account, and uses these to adjust
+    the weather parameters during calculations.
+
+    Heimdall DLR is aggregated over the entire line. Using a 5-minute sliding window, the minimum
+    ampacity are calculated for each window.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion]):  Default:
+            CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200, ProblemDetails]]
+     """
+
+
+    kwargs = _get_kwargs(
+        line_id=line_id,
+x_region=x_region,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion.EU,
+
+) -> Optional[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200, ProblemDetails]]:
+    """ Get latest Heimdall DLR
+
+     This endpoint returns the most recent Heimdall Dynamic Line Rating (DLR) for the line.
+
+    Heimdall DLR is calculated according to our own proprietary method, based on the CIGRE TB-601
+    standard for thermal calculation for OHLs.
+    This method also takes the conductor temperature and current into account, and uses these to adjust
+    the weather parameters during calculations.
+
+    Heimdall DLR is aggregated over the entire line. Using a 5-minute sliding window, the minimum
+    ampacity are calculated for each window.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion]):  Default:
+            CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200, ProblemDetails]
+     """
+
+
+    return sync_detailed(
+        line_id=line_id,
+client=client,
+x_region=x_region,
+
+    ).parsed
+
+async def asyncio_detailed(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion.EU,
+
+) -> Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200, ProblemDetails]]:
+    """ Get latest Heimdall DLR
+
+     This endpoint returns the most recent Heimdall Dynamic Line Rating (DLR) for the line.
+
+    Heimdall DLR is calculated according to our own proprietary method, based on the CIGRE TB-601
+    standard for thermal calculation for OHLs.
+    This method also takes the conductor temperature and current into account, and uses these to adjust
+    the weather parameters during calculations.
+
+    Heimdall DLR is aggregated over the entire line. Using a 5-minute sliding window, the minimum
+    ampacity are calculated for each window.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion]):  Default:
+            CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200, ProblemDetails]]
+     """
+
+
+    kwargs = _get_kwargs(
+        line_id=line_id,
+x_region=x_region,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion.EU,
+
+) -> Optional[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200, ProblemDetails]]:
+    """ Get latest Heimdall DLR
+
+     This endpoint returns the most recent Heimdall Dynamic Line Rating (DLR) for the line.
+
+    Heimdall DLR is calculated according to our own proprietary method, based on the CIGRE TB-601
+    standard for thermal calculation for OHLs.
+    This method also takes the conductor temperature and current into account, and uses these to adjust
+    the weather parameters during calculations.
+
+    Heimdall DLR is aggregated over the entire line. Using a 5-minute sliding window, the minimum
+    ampacity are calculated for each window.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion]):  Default:
+            CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200, ProblemDetails]
+     """
+
+
+    return (await asyncio_detailed(
+        line_id=line_id,
+client=client,
+x_region=x_region,
+
+    )).parsed

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts.py
@@ -1,0 +1,259 @@
+from http import HTTPStatus
+from typing import Any, Optional, Union, cast
+
+import httpx
+
+from ...client import AuthenticatedClient, Client
+from ...types import Response, UNSET
+from ... import errors
+
+from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_response_200 import CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200
+from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_x_region import CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion
+from ...models.problem_details import ProblemDetails
+from ...types import UNSET, Unset
+from typing import cast
+from typing import Union
+from uuid import UUID
+
+
+
+def _get_kwargs(
+    line_id: UUID,
+    *,
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion.EU,
+
+) -> dict[str, Any]:
+    headers: dict[str, Any] = {}
+    if not isinstance(x_region, Unset):
+        headers["x-region"] = str(x_region)
+
+
+
+
+    
+
+    
+
+    _kwargs: dict[str, Any] = {
+        "method": "get",
+        "url": "/capacity_monitoring/v1/lines/{line_id}/heimdall_dlrs/forecasts".format(line_id=line_id,),
+    }
+
+
+    _kwargs["headers"] = headers
+    return _kwargs
+
+
+def _parse_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Optional[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200, ProblemDetails]]:
+    if response.status_code == 200:
+        response_200 = CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200.from_dict(response.json())
+
+
+
+        return response_200
+    if response.status_code == 401:
+        response_401 = cast(Any, None)
+        return response_401
+    if response.status_code == 403:
+        response_403 = ProblemDetails.from_dict(response.json())
+
+
+
+        return response_403
+    if response.status_code == 404:
+        response_404 = cast(Any, None)
+        return response_404
+    if response.status_code == 500:
+        response_500 = ProblemDetails.from_dict(response.json())
+
+
+
+        return response_500
+    if client.raise_on_unexpected_status:
+        raise errors.UnexpectedStatus(response.status_code, response.content)
+    else:
+        return None
+
+
+def _build_response(*, client: Union[AuthenticatedClient, Client], response: httpx.Response) -> Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200, ProblemDetails]]:
+    return Response(
+        status_code=HTTPStatus(response.status_code),
+        content=response.content,
+        headers=response.headers,
+        parsed=_parse_response(client=client, response=response),
+    )
+
+
+def sync_detailed(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion.EU,
+
+) -> Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200, ProblemDetails]]:
+    """ Get latest Heimdall DLR forecasts
+
+     This endpoint returns the most recent Heimdall Dynamic Line Rating (DLR) forecasts for the line.
+
+    The forecasted hours returned by the endpoint are set to 72 hours, and are provided in 1-hour
+    intervals.
+
+    The response contains a series of buckets, each with a timestamp and predictions based on different
+    values of confidence levels `p80`, `p90`, `p95` and `p99`.
+
+    For each unique timestamp and confidence level, we pick the value from the span which has the lowest
+    ampacity value as this will be the dimensioning value for the line.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion]):
+            Default: CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200, ProblemDetails]]
+     """
+
+
+    kwargs = _get_kwargs(
+        line_id=line_id,
+x_region=x_region,
+
+    )
+
+    response = client.get_httpx_client().request(
+        **kwargs,
+    )
+
+    return _build_response(client=client, response=response)
+
+def sync(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion.EU,
+
+) -> Optional[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200, ProblemDetails]]:
+    """ Get latest Heimdall DLR forecasts
+
+     This endpoint returns the most recent Heimdall Dynamic Line Rating (DLR) forecasts for the line.
+
+    The forecasted hours returned by the endpoint are set to 72 hours, and are provided in 1-hour
+    intervals.
+
+    The response contains a series of buckets, each with a timestamp and predictions based on different
+    values of confidence levels `p80`, `p90`, `p95` and `p99`.
+
+    For each unique timestamp and confidence level, we pick the value from the span which has the lowest
+    ampacity value as this will be the dimensioning value for the line.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion]):
+            Default: CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200, ProblemDetails]
+     """
+
+
+    return sync_detailed(
+        line_id=line_id,
+client=client,
+x_region=x_region,
+
+    ).parsed
+
+async def asyncio_detailed(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion.EU,
+
+) -> Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200, ProblemDetails]]:
+    """ Get latest Heimdall DLR forecasts
+
+     This endpoint returns the most recent Heimdall Dynamic Line Rating (DLR) forecasts for the line.
+
+    The forecasted hours returned by the endpoint are set to 72 hours, and are provided in 1-hour
+    intervals.
+
+    The response contains a series of buckets, each with a timestamp and predictions based on different
+    values of confidence levels `p80`, `p90`, `p95` and `p99`.
+
+    For each unique timestamp and confidence level, we pick the value from the span which has the lowest
+    ampacity value as this will be the dimensioning value for the line.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion]):
+            Default: CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Response[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200, ProblemDetails]]
+     """
+
+
+    kwargs = _get_kwargs(
+        line_id=line_id,
+x_region=x_region,
+
+    )
+
+    response = await client.get_async_httpx_client().request(
+        **kwargs
+    )
+
+    return _build_response(client=client, response=response)
+
+async def asyncio(
+    line_id: UUID,
+    *,
+    client: Union[AuthenticatedClient, Client],
+    x_region: Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion] = CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion.EU,
+
+) -> Optional[Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200, ProblemDetails]]:
+    """ Get latest Heimdall DLR forecasts
+
+     This endpoint returns the most recent Heimdall Dynamic Line Rating (DLR) forecasts for the line.
+
+    The forecasted hours returned by the endpoint are set to 72 hours, and are provided in 1-hour
+    intervals.
+
+    The response contains a series of buckets, each with a timestamp and predictions based on different
+    values of confidence levels `p80`, `p90`, `p95` and `p99`.
+
+    For each unique timestamp and confidence level, we pick the value from the span which has the lowest
+    ampacity value as this will be the dimensioning value for the line.
+
+    Args:
+        line_id (UUID):
+        x_region (Union[Unset, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion]):
+            Default: CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion.EU.
+
+    Raises:
+        errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
+        httpx.TimeoutException: If the request takes longer than Client.timeout.
+
+    Returns:
+        Union[Any, CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200, ProblemDetails]
+     """
+
+
+    return (await asyncio_detailed(
+        line_id=line_id,
+client=client,
+x_region=x_region,
+
+    )).parsed

--- a/python/heimdall_api_client/capacity_monitoring_api_client/client.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/client.py
@@ -1,0 +1,271 @@
+import ssl
+from typing import Any, Union, Optional
+
+from attrs import define, field, evolve
+import httpx
+
+
+
+
+
+@define
+class Client:
+    """A class for keeping track of data related to the API
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+    """
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: Optional[httpx.Client] = field(default=None, init=False)
+    _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
+
+    def with_headers(self, headers: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "Client":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "Client":
+        """Get a new client matching this one with a new timeout (in seconds)"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "Client":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "Client":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "Client":
+        """Manually the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "Client":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+
+
+@define
+class AuthenticatedClient:
+    """A Client which has been authenticated for use on secured endpoints
+
+    The following are accepted as keyword arguments and will be used to construct httpx Clients internally:
+
+        ``base_url``: The base URL for the API, all requests are made to a relative path to this URL
+
+        ``cookies``: A dictionary of cookies to be sent with every request
+
+        ``headers``: A dictionary of headers to be sent with every request
+
+        ``timeout``: The maximum amount of a time a request can take. API functions will raise
+        httpx.TimeoutException if this is exceeded.
+
+        ``verify_ssl``: Whether or not to verify the SSL certificate of the API server. This should be True in production,
+        but can be set to False for testing purposes.
+
+        ``follow_redirects``: Whether or not to follow redirects. Default value is False.
+
+        ``httpx_args``: A dictionary of additional arguments to be passed to the ``httpx.Client`` and ``httpx.AsyncClient`` constructor.
+
+
+    Attributes:
+        raise_on_unexpected_status: Whether or not to raise an errors.UnexpectedStatus if the API returns a
+            status code that was not documented in the source OpenAPI document. Can also be provided as a keyword
+            argument to the constructor.
+        token: The token to use for authentication
+        prefix: The prefix to use for the Authorization header
+        auth_header_name: The name of the Authorization header
+    """
+
+    raise_on_unexpected_status: bool = field(default=False, kw_only=True)
+    _base_url: str = field(alias="base_url")
+    _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
+    _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
+    _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
+    _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
+    _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
+    _client: Optional[httpx.Client] = field(default=None, init=False)
+    _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
+
+    token: str
+    prefix: str = "Bearer"
+    auth_header_name: str = "Authorization"
+
+    def with_headers(self, headers: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional headers"""
+        if self._client is not None:
+            self._client.headers.update(headers)
+        if self._async_client is not None:
+            self._async_client.headers.update(headers)
+        return evolve(self, headers={**self._headers, **headers})
+
+    def with_cookies(self, cookies: dict[str, str]) -> "AuthenticatedClient":
+        """Get a new client matching this one with additional cookies"""
+        if self._client is not None:
+            self._client.cookies.update(cookies)
+        if self._async_client is not None:
+            self._async_client.cookies.update(cookies)
+        return evolve(self, cookies={**self._cookies, **cookies})
+
+    def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
+        """Get a new client matching this one with a new timeout (in seconds)"""
+        if self._client is not None:
+            self._client.timeout = timeout
+        if self._async_client is not None:
+            self._async_client.timeout = timeout
+        return evolve(self, timeout=timeout)
+
+    def set_httpx_client(self, client: httpx.Client) -> "AuthenticatedClient":
+        """Manually set the underlying httpx.Client
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._client = client
+        return self
+
+    def get_httpx_client(self) -> httpx.Client:
+        """Get the underlying httpx.Client, constructing a new one if not previously set"""
+        if self._client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._client = httpx.Client(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._client
+
+    def __enter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for self.client—you cannot enter twice (see httpx docs)"""
+        self.get_httpx_client().__enter__()
+        return self
+
+    def __exit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for internal httpx.Client (see httpx docs)"""
+        self.get_httpx_client().__exit__(*args, **kwargs)
+
+    def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "AuthenticatedClient":
+        """Manually the underlying httpx.AsyncClient
+
+        **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
+        """
+        self._async_client = async_client
+        return self
+
+    def get_async_httpx_client(self) -> httpx.AsyncClient:
+        """Get the underlying httpx.AsyncClient, constructing a new one if not previously set"""
+        if self._async_client is None:
+            self._headers[self.auth_header_name] = f"{self.prefix} {self.token}" if self.prefix else self.token
+            self._async_client = httpx.AsyncClient(
+                base_url=self._base_url,
+                cookies=self._cookies,
+                headers=self._headers,
+                timeout=self._timeout,
+                verify=self._verify_ssl,
+                follow_redirects=self._follow_redirects,
+                **self._httpx_args,
+            )
+        return self._async_client
+
+    async def __aenter__(self) -> "AuthenticatedClient":
+        """Enter a context manager for underlying httpx.AsyncClient—you cannot enter twice (see httpx docs)"""
+        await self.get_async_httpx_client().__aenter__()
+        return self
+
+    async def __aexit__(self, *args: Any, **kwargs: Any) -> None:
+        """Exit a context manager for underlying httpx.AsyncClient (see httpx docs)"""
+        await self.get_async_httpx_client().__aexit__(*args, **kwargs)
+

--- a/python/heimdall_api_client/capacity_monitoring_api_client/errors.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/errors.py
@@ -1,0 +1,14 @@
+""" Contains shared errors types that can be raised from API functions """
+
+class UnexpectedStatus(Exception):
+    """Raised by api functions when the response status an undocumented status and Client.raise_on_unexpected_status is True"""
+
+    def __init__(self, status_code: int, content: bytes):
+        self.status_code = status_code
+        self.content = content
+
+        super().__init__(
+            f"Unexpected status code: {status_code}\n\nResponse content:\n{content.decode(errors='ignore')}"
+        )
+
+__all__ = ["UnexpectedStatus"]

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/__init__.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/__init__.py
@@ -1,0 +1,59 @@
+""" Contains all the data models used in inputs/outputs """
+
+from .aar import Aar
+from .api_response import ApiResponse
+from .capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_response_200 import CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200
+from .capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_x_region import CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion
+from .capacity_monitoring_v1_facilities_get_latest_circuit_rating_response_200 import CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200
+from .capacity_monitoring_v1_facilities_get_latest_circuit_rating_x_region import CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion
+from .capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_response_200 import CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200
+from .capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_x_region import CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion
+from .capacity_monitoring_v1_lines_get_latest_heimdall_aar_response_200 import CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200
+from .capacity_monitoring_v1_lines_get_latest_heimdall_aar_x_region import CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion
+from .capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_response_200 import CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200
+from .capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_x_region import CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion
+from .capacity_monitoring_v1_lines_get_latest_heimdall_dlr_response_200 import CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200
+from .capacity_monitoring_v1_lines_get_latest_heimdall_dlr_x_region import CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion
+from .circuit_rating import CircuitRating
+from .circuit_rating_forecasts import CircuitRatingForecasts
+from .dlr import Dlr
+from .heimdall_aar_forecasts import HeimdallAarForecasts
+from .heimdall_dlr_forecasts import HeimdallDlrForecasts
+from .latest_aar import LatestAar
+from .latest_circuit_rating import LatestCircuitRating
+from .latest_dlr import LatestDlr
+from .predicted_circuit_rating_forecast import PredictedCircuitRatingForecast
+from .predicted_forecast import PredictedForecast
+from .probabilistic_circuit_rating_ampacity import ProbabilisticCircuitRatingAmpacity
+from .probabilistic_line_ampacity import ProbabilisticLineAmpacity
+from .problem_details import ProblemDetails
+
+__all__ = (
+    "Aar",
+    "ApiResponse",
+    "CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200",
+    "CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion",
+    "CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200",
+    "CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion",
+    "CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200",
+    "CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion",
+    "CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200",
+    "CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion",
+    "CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200",
+    "CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion",
+    "CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200",
+    "CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion",
+    "CircuitRating",
+    "CircuitRatingForecasts",
+    "Dlr",
+    "HeimdallAarForecasts",
+    "HeimdallDlrForecasts",
+    "LatestAar",
+    "LatestCircuitRating",
+    "LatestDlr",
+    "PredictedCircuitRatingForecast",
+    "PredictedForecast",
+    "ProbabilisticCircuitRatingAmpacity",
+    "ProbabilisticLineAmpacity",
+    "ProblemDetails",
+)

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/aar.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/aar.py
@@ -1,0 +1,89 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from dateutil.parser import isoparse
+from typing import cast
+import datetime
+
+
+
+
+
+
+T = TypeVar("T", bound="Aar")
+
+
+
+@_attrs_define
+class Aar:
+    """ 
+        Attributes:
+            timestamp (datetime.datetime): Time (in UTC) when the Heimdall AAR was calculated. Example:
+                2024-07-01T12:00:00.001Z.
+            value (float): The minimum calculated ampacity (in amperes) at the given timestamp. Example: 375.4.
+     """
+
+    timestamp: datetime.datetime
+    value: float
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        timestamp = self.timestamp.isoformat()
+
+        value = self.value
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "timestamp": timestamp,
+            "value": value,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        timestamp = isoparse(d.pop("timestamp"))
+
+
+
+
+        value = d.pop("value")
+
+        aar = cls(
+            timestamp=timestamp,
+            value=value,
+        )
+
+
+        aar.additional_properties = d
+        return aar
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/api_response.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/api_response.py
@@ -1,0 +1,74 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+
+
+
+
+
+
+T = TypeVar("T", bound="ApiResponse")
+
+
+
+@_attrs_define
+class ApiResponse:
+    """ 
+        Attributes:
+            data (Any):
+     """
+
+    data: Any
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        data = self.data
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "data": data,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        data = d.pop("data")
+
+        api_response = cls(
+            data=data,
+        )
+
+
+        api_response.additional_properties = d
+        return api_response
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_response_200.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_response_200.py
@@ -1,0 +1,82 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from typing import cast
+
+if TYPE_CHECKING:
+  from ..models.circuit_rating_forecasts import CircuitRatingForecasts
+
+
+
+
+
+T = TypeVar("T", bound="CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200")
+
+
+
+@_attrs_define
+class CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200:
+    """ 
+        Attributes:
+            data (CircuitRatingForecasts):
+     """
+
+    data: 'CircuitRatingForecasts'
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.circuit_rating_forecasts import CircuitRatingForecasts
+        data = self.data.to_dict()
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "data": data,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.circuit_rating_forecasts import CircuitRatingForecasts
+        d = dict(src_dict)
+        data = CircuitRatingForecasts.from_dict(d.pop("data"))
+
+
+
+
+        capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_response_200 = cls(
+            data=data,
+        )
+
+
+        capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_response_200.additional_properties = d
+        return capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_x_region.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_x_region.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+class CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion(str, Enum):
+    EU = "eu"
+    US = "us"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_facilities_get_latest_circuit_rating_response_200.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_facilities_get_latest_circuit_rating_response_200.py
@@ -1,0 +1,82 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from typing import cast
+
+if TYPE_CHECKING:
+  from ..models.latest_circuit_rating import LatestCircuitRating
+
+
+
+
+
+T = TypeVar("T", bound="CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200")
+
+
+
+@_attrs_define
+class CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200:
+    """ 
+        Attributes:
+            data (LatestCircuitRating):
+     """
+
+    data: 'LatestCircuitRating'
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.latest_circuit_rating import LatestCircuitRating
+        data = self.data.to_dict()
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "data": data,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.latest_circuit_rating import LatestCircuitRating
+        d = dict(src_dict)
+        data = LatestCircuitRating.from_dict(d.pop("data"))
+
+
+
+
+        capacity_monitoring_v1_facilities_get_latest_circuit_rating_response_200 = cls(
+            data=data,
+        )
+
+
+        capacity_monitoring_v1_facilities_get_latest_circuit_rating_response_200.additional_properties = d
+        return capacity_monitoring_v1_facilities_get_latest_circuit_rating_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_facilities_get_latest_circuit_rating_x_region.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_facilities_get_latest_circuit_rating_x_region.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+class CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion(str, Enum):
+    EU = "eu"
+    US = "us"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_response_200.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_response_200.py
@@ -1,0 +1,82 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from typing import cast
+
+if TYPE_CHECKING:
+  from ..models.heimdall_aar_forecasts import HeimdallAarForecasts
+
+
+
+
+
+T = TypeVar("T", bound="CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200")
+
+
+
+@_attrs_define
+class CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200:
+    """ 
+        Attributes:
+            data (HeimdallAarForecasts):
+     """
+
+    data: 'HeimdallAarForecasts'
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.heimdall_aar_forecasts import HeimdallAarForecasts
+        data = self.data.to_dict()
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "data": data,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.heimdall_aar_forecasts import HeimdallAarForecasts
+        d = dict(src_dict)
+        data = HeimdallAarForecasts.from_dict(d.pop("data"))
+
+
+
+
+        capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_response_200 = cls(
+            data=data,
+        )
+
+
+        capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_response_200.additional_properties = d
+        return capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_x_region.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_x_region.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+class CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion(str, Enum):
+    EU = "eu"
+    US = "us"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_aar_response_200.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_aar_response_200.py
@@ -1,0 +1,82 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from typing import cast
+
+if TYPE_CHECKING:
+  from ..models.latest_aar import LatestAar
+
+
+
+
+
+T = TypeVar("T", bound="CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200")
+
+
+
+@_attrs_define
+class CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200:
+    """ 
+        Attributes:
+            data (LatestAar):
+     """
+
+    data: 'LatestAar'
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.latest_aar import LatestAar
+        data = self.data.to_dict()
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "data": data,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.latest_aar import LatestAar
+        d = dict(src_dict)
+        data = LatestAar.from_dict(d.pop("data"))
+
+
+
+
+        capacity_monitoring_v1_lines_get_latest_heimdall_aar_response_200 = cls(
+            data=data,
+        )
+
+
+        capacity_monitoring_v1_lines_get_latest_heimdall_aar_response_200.additional_properties = d
+        return capacity_monitoring_v1_lines_get_latest_heimdall_aar_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_aar_x_region.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_aar_x_region.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+class CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion(str, Enum):
+    EU = "eu"
+    US = "us"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_response_200.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_response_200.py
@@ -1,0 +1,82 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from typing import cast
+
+if TYPE_CHECKING:
+  from ..models.heimdall_dlr_forecasts import HeimdallDlrForecasts
+
+
+
+
+
+T = TypeVar("T", bound="CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200")
+
+
+
+@_attrs_define
+class CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200:
+    """ 
+        Attributes:
+            data (HeimdallDlrForecasts):
+     """
+
+    data: 'HeimdallDlrForecasts'
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.heimdall_dlr_forecasts import HeimdallDlrForecasts
+        data = self.data.to_dict()
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "data": data,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.heimdall_dlr_forecasts import HeimdallDlrForecasts
+        d = dict(src_dict)
+        data = HeimdallDlrForecasts.from_dict(d.pop("data"))
+
+
+
+
+        capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_response_200 = cls(
+            data=data,
+        )
+
+
+        capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_response_200.additional_properties = d
+        return capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_x_region.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_x_region.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+class CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion(str, Enum):
+    EU = "eu"
+    US = "us"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_response_200.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_response_200.py
@@ -1,0 +1,82 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from typing import cast
+
+if TYPE_CHECKING:
+  from ..models.latest_dlr import LatestDlr
+
+
+
+
+
+T = TypeVar("T", bound="CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200")
+
+
+
+@_attrs_define
+class CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200:
+    """ 
+        Attributes:
+            data (LatestDlr):
+     """
+
+    data: 'LatestDlr'
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.latest_dlr import LatestDlr
+        data = self.data.to_dict()
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "data": data,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.latest_dlr import LatestDlr
+        d = dict(src_dict)
+        data = LatestDlr.from_dict(d.pop("data"))
+
+
+
+
+        capacity_monitoring_v1_lines_get_latest_heimdall_dlr_response_200 = cls(
+            data=data,
+        )
+
+
+        capacity_monitoring_v1_lines_get_latest_heimdall_dlr_response_200.additional_properties = d
+        return capacity_monitoring_v1_lines_get_latest_heimdall_dlr_response_200
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_x_region.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_x_region.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+class CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion(str, Enum):
+    EU = "eu"
+    US = "us"
+
+    def __str__(self) -> str:
+        return str(self.value)

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/circuit_rating.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/circuit_rating.py
@@ -1,0 +1,89 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from dateutil.parser import isoparse
+from typing import cast
+import datetime
+
+
+
+
+
+
+T = TypeVar("T", bound="CircuitRating")
+
+
+
+@_attrs_define
+class CircuitRating:
+    """ 
+        Attributes:
+            timestamp (datetime.datetime): Time (in UTC) when the circuit rating was calculated. Example:
+                2024-07-01T12:00:00.001Z.
+            value (float): The minimum calculated ampacity (in amperes) at the given timestamp. Example: 375.4.
+     """
+
+    timestamp: datetime.datetime
+    value: float
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        timestamp = self.timestamp.isoformat()
+
+        value = self.value
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "timestamp": timestamp,
+            "value": value,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        timestamp = isoparse(d.pop("timestamp"))
+
+
+
+
+        value = d.pop("value")
+
+        circuit_rating = cls(
+            timestamp=timestamp,
+            value=value,
+        )
+
+
+        circuit_rating.additional_properties = d
+        return circuit_rating
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/circuit_rating_forecasts.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/circuit_rating_forecasts.py
@@ -1,0 +1,123 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from dateutil.parser import isoparse
+from typing import cast
+import datetime
+
+if TYPE_CHECKING:
+  from ..models.predicted_circuit_rating_forecast import PredictedCircuitRatingForecast
+
+
+
+
+
+T = TypeVar("T", bound="CircuitRatingForecasts")
+
+
+
+@_attrs_define
+class CircuitRatingForecasts:
+    """ 
+        Attributes:
+            metric (str): What kind of data does this response contain. Example: Circuit rating forecast.
+            unit (str): The unit of the values in the response. Example: Ampere.
+            updated_timestamp (datetime.datetime): The timestamp when the forecasts were last updated. Example:
+                2024-07-01T12:00:00.001Z.
+            circuit_rating_forecasts (list['PredictedCircuitRatingForecast']): The forecasts for a 1 hour interval starting
+                from the `updated_timestamp`. The predicted forecasts includes different percentages of confidence.
+     """
+
+    metric: str
+    unit: str
+    updated_timestamp: datetime.datetime
+    circuit_rating_forecasts: list['PredictedCircuitRatingForecast']
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.predicted_circuit_rating_forecast import PredictedCircuitRatingForecast
+        metric = self.metric
+
+        unit = self.unit
+
+        updated_timestamp = self.updated_timestamp.isoformat()
+
+        circuit_rating_forecasts = []
+        for circuit_rating_forecasts_item_data in self.circuit_rating_forecasts:
+            circuit_rating_forecasts_item = circuit_rating_forecasts_item_data.to_dict()
+            circuit_rating_forecasts.append(circuit_rating_forecasts_item)
+
+
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "metric": metric,
+            "unit": unit,
+            "updated_timestamp": updated_timestamp,
+            "circuit_rating_forecasts": circuit_rating_forecasts,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.predicted_circuit_rating_forecast import PredictedCircuitRatingForecast
+        d = dict(src_dict)
+        metric = d.pop("metric")
+
+        unit = d.pop("unit")
+
+        updated_timestamp = isoparse(d.pop("updated_timestamp"))
+
+
+
+
+        circuit_rating_forecasts = []
+        _circuit_rating_forecasts = d.pop("circuit_rating_forecasts")
+        for circuit_rating_forecasts_item_data in (_circuit_rating_forecasts):
+            circuit_rating_forecasts_item = PredictedCircuitRatingForecast.from_dict(circuit_rating_forecasts_item_data)
+
+
+
+            circuit_rating_forecasts.append(circuit_rating_forecasts_item)
+
+
+        circuit_rating_forecasts = cls(
+            metric=metric,
+            unit=unit,
+            updated_timestamp=updated_timestamp,
+            circuit_rating_forecasts=circuit_rating_forecasts,
+        )
+
+
+        circuit_rating_forecasts.additional_properties = d
+        return circuit_rating_forecasts
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/dlr.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/dlr.py
@@ -1,0 +1,89 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from dateutil.parser import isoparse
+from typing import cast
+import datetime
+
+
+
+
+
+
+T = TypeVar("T", bound="Dlr")
+
+
+
+@_attrs_define
+class Dlr:
+    """ 
+        Attributes:
+            timestamp (datetime.datetime): Time (in UTC) when the Heimdall DLR was calculated. Example:
+                2024-07-01T12:00:00.001Z.
+            value (float): The minimum calculated ampacity (in amperes) at the given timestamp. Example: 375.4.
+     """
+
+    timestamp: datetime.datetime
+    value: float
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        timestamp = self.timestamp.isoformat()
+
+        value = self.value
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "timestamp": timestamp,
+            "value": value,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        timestamp = isoparse(d.pop("timestamp"))
+
+
+
+
+        value = d.pop("value")
+
+        dlr = cls(
+            timestamp=timestamp,
+            value=value,
+        )
+
+
+        dlr.additional_properties = d
+        return dlr
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/heimdall_aar_forecasts.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/heimdall_aar_forecasts.py
@@ -1,0 +1,123 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from dateutil.parser import isoparse
+from typing import cast
+import datetime
+
+if TYPE_CHECKING:
+  from ..models.predicted_forecast import PredictedForecast
+
+
+
+
+
+T = TypeVar("T", bound="HeimdallAarForecasts")
+
+
+
+@_attrs_define
+class HeimdallAarForecasts:
+    """ 
+        Attributes:
+            metric (str): What kind of data does this response contain. Example: Heimdall AAR forecast.
+            unit (str): The unit of the values in the response. Example: Ampere.
+            updated_timestamp (datetime.datetime): The timestamp when the forecasts were last updated. Example:
+                2024-07-01T12:00:00.001Z.
+            aar_forecasts (list['PredictedForecast']): The forecasts for a 1 hour interval starting from the
+                `updated_timestamp`. The predicted forecasts includes different percentages of confidence.
+     """
+
+    metric: str
+    unit: str
+    updated_timestamp: datetime.datetime
+    aar_forecasts: list['PredictedForecast']
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.predicted_forecast import PredictedForecast
+        metric = self.metric
+
+        unit = self.unit
+
+        updated_timestamp = self.updated_timestamp.isoformat()
+
+        aar_forecasts = []
+        for aar_forecasts_item_data in self.aar_forecasts:
+            aar_forecasts_item = aar_forecasts_item_data.to_dict()
+            aar_forecasts.append(aar_forecasts_item)
+
+
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "metric": metric,
+            "unit": unit,
+            "updated_timestamp": updated_timestamp,
+            "aar_forecasts": aar_forecasts,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.predicted_forecast import PredictedForecast
+        d = dict(src_dict)
+        metric = d.pop("metric")
+
+        unit = d.pop("unit")
+
+        updated_timestamp = isoparse(d.pop("updated_timestamp"))
+
+
+
+
+        aar_forecasts = []
+        _aar_forecasts = d.pop("aar_forecasts")
+        for aar_forecasts_item_data in (_aar_forecasts):
+            aar_forecasts_item = PredictedForecast.from_dict(aar_forecasts_item_data)
+
+
+
+            aar_forecasts.append(aar_forecasts_item)
+
+
+        heimdall_aar_forecasts = cls(
+            metric=metric,
+            unit=unit,
+            updated_timestamp=updated_timestamp,
+            aar_forecasts=aar_forecasts,
+        )
+
+
+        heimdall_aar_forecasts.additional_properties = d
+        return heimdall_aar_forecasts
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/heimdall_dlr_forecasts.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/heimdall_dlr_forecasts.py
@@ -1,0 +1,123 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from dateutil.parser import isoparse
+from typing import cast
+import datetime
+
+if TYPE_CHECKING:
+  from ..models.predicted_forecast import PredictedForecast
+
+
+
+
+
+T = TypeVar("T", bound="HeimdallDlrForecasts")
+
+
+
+@_attrs_define
+class HeimdallDlrForecasts:
+    """ 
+        Attributes:
+            metric (str): What kind of data does this response contain. Example: Heimdall DLR forecast.
+            unit (str): The unit of the values in the response. Example: Ampere.
+            updated_timestamp (datetime.datetime): The timestamp when the forecasts were last updated. Example:
+                2024-07-01T12:00:00.001Z.
+            dlr_forecasts (list['PredictedForecast']): The forecasts for a 1 hour interval starting from the
+                `updated_timestamp`. The predicted forecasts includes different percentages of confidence.
+     """
+
+    metric: str
+    unit: str
+    updated_timestamp: datetime.datetime
+    dlr_forecasts: list['PredictedForecast']
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.predicted_forecast import PredictedForecast
+        metric = self.metric
+
+        unit = self.unit
+
+        updated_timestamp = self.updated_timestamp.isoformat()
+
+        dlr_forecasts = []
+        for dlr_forecasts_item_data in self.dlr_forecasts:
+            dlr_forecasts_item = dlr_forecasts_item_data.to_dict()
+            dlr_forecasts.append(dlr_forecasts_item)
+
+
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "metric": metric,
+            "unit": unit,
+            "updated_timestamp": updated_timestamp,
+            "dlr_forecasts": dlr_forecasts,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.predicted_forecast import PredictedForecast
+        d = dict(src_dict)
+        metric = d.pop("metric")
+
+        unit = d.pop("unit")
+
+        updated_timestamp = isoparse(d.pop("updated_timestamp"))
+
+
+
+
+        dlr_forecasts = []
+        _dlr_forecasts = d.pop("dlr_forecasts")
+        for dlr_forecasts_item_data in (_dlr_forecasts):
+            dlr_forecasts_item = PredictedForecast.from_dict(dlr_forecasts_item_data)
+
+
+
+            dlr_forecasts.append(dlr_forecasts_item)
+
+
+        heimdall_dlr_forecasts = cls(
+            metric=metric,
+            unit=unit,
+            updated_timestamp=updated_timestamp,
+            dlr_forecasts=dlr_forecasts,
+        )
+
+
+        heimdall_dlr_forecasts.additional_properties = d
+        return heimdall_dlr_forecasts
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/latest_aar.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/latest_aar.py
@@ -1,0 +1,98 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from typing import cast
+
+if TYPE_CHECKING:
+  from ..models.aar import Aar
+
+
+
+
+
+T = TypeVar("T", bound="LatestAar")
+
+
+
+@_attrs_define
+class LatestAar:
+    """ 
+        Attributes:
+            metric (str): What kind of data does this response contain. Example: Heimdall AAR.
+            unit (str): The unit of the value in the response. Example: Ampere.
+            aar (Aar):
+     """
+
+    metric: str
+    unit: str
+    aar: 'Aar'
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.aar import Aar
+        metric = self.metric
+
+        unit = self.unit
+
+        aar = self.aar.to_dict()
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "metric": metric,
+            "unit": unit,
+            "aar": aar,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.aar import Aar
+        d = dict(src_dict)
+        metric = d.pop("metric")
+
+        unit = d.pop("unit")
+
+        aar = Aar.from_dict(d.pop("aar"))
+
+
+
+
+        latest_aar = cls(
+            metric=metric,
+            unit=unit,
+            aar=aar,
+        )
+
+
+        latest_aar.additional_properties = d
+        return latest_aar
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/latest_circuit_rating.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/latest_circuit_rating.py
@@ -1,0 +1,98 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from typing import cast
+
+if TYPE_CHECKING:
+  from ..models.circuit_rating import CircuitRating
+
+
+
+
+
+T = TypeVar("T", bound="LatestCircuitRating")
+
+
+
+@_attrs_define
+class LatestCircuitRating:
+    """ 
+        Attributes:
+            metric (str): What kind of data does this response contain. Example: Circuit rating.
+            unit (str): The unit of the value in the response. Example: Ampere.
+            circuit_rating (CircuitRating):
+     """
+
+    metric: str
+    unit: str
+    circuit_rating: 'CircuitRating'
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.circuit_rating import CircuitRating
+        metric = self.metric
+
+        unit = self.unit
+
+        circuit_rating = self.circuit_rating.to_dict()
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "metric": metric,
+            "unit": unit,
+            "circuit_rating": circuit_rating,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.circuit_rating import CircuitRating
+        d = dict(src_dict)
+        metric = d.pop("metric")
+
+        unit = d.pop("unit")
+
+        circuit_rating = CircuitRating.from_dict(d.pop("circuit_rating"))
+
+
+
+
+        latest_circuit_rating = cls(
+            metric=metric,
+            unit=unit,
+            circuit_rating=circuit_rating,
+        )
+
+
+        latest_circuit_rating.additional_properties = d
+        return latest_circuit_rating
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/latest_dlr.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/latest_dlr.py
@@ -1,0 +1,98 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from typing import cast
+
+if TYPE_CHECKING:
+  from ..models.dlr import Dlr
+
+
+
+
+
+T = TypeVar("T", bound="LatestDlr")
+
+
+
+@_attrs_define
+class LatestDlr:
+    """ 
+        Attributes:
+            metric (str): What kind of data does this response contain. Example: Heimdall DLR.
+            unit (str): The unit of the value in the response. Example: Ampere.
+            dlr (Dlr):
+     """
+
+    metric: str
+    unit: str
+    dlr: 'Dlr'
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.dlr import Dlr
+        metric = self.metric
+
+        unit = self.unit
+
+        dlr = self.dlr.to_dict()
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "metric": metric,
+            "unit": unit,
+            "dlr": dlr,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.dlr import Dlr
+        d = dict(src_dict)
+        metric = d.pop("metric")
+
+        unit = d.pop("unit")
+
+        dlr = Dlr.from_dict(d.pop("dlr"))
+
+
+
+
+        latest_dlr = cls(
+            metric=metric,
+            unit=unit,
+            dlr=dlr,
+        )
+
+
+        latest_dlr.additional_properties = d
+        return latest_dlr
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/predicted_circuit_rating_forecast.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/predicted_circuit_rating_forecast.py
@@ -1,0 +1,139 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from dateutil.parser import isoparse
+from typing import cast
+import datetime
+
+if TYPE_CHECKING:
+  from ..models.probabilistic_circuit_rating_ampacity import ProbabilisticCircuitRatingAmpacity
+
+
+
+
+
+T = TypeVar("T", bound="PredictedCircuitRatingForecast")
+
+
+
+@_attrs_define
+class PredictedCircuitRatingForecast:
+    """ 
+        Attributes:
+            timestamp (datetime.datetime): Timestamp for the predicted forecast. Example: 2024-07-01T12:00:00.001Z.
+            prediction (ProbabilisticCircuitRatingAmpacity):
+            p80 (ProbabilisticCircuitRatingAmpacity):
+            p90 (ProbabilisticCircuitRatingAmpacity):
+            p95 (ProbabilisticCircuitRatingAmpacity):
+            p99 (ProbabilisticCircuitRatingAmpacity):
+     """
+
+    timestamp: datetime.datetime
+    prediction: 'ProbabilisticCircuitRatingAmpacity'
+    p80: 'ProbabilisticCircuitRatingAmpacity'
+    p90: 'ProbabilisticCircuitRatingAmpacity'
+    p95: 'ProbabilisticCircuitRatingAmpacity'
+    p99: 'ProbabilisticCircuitRatingAmpacity'
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.probabilistic_circuit_rating_ampacity import ProbabilisticCircuitRatingAmpacity
+        timestamp = self.timestamp.isoformat()
+
+        prediction = self.prediction.to_dict()
+
+        p80 = self.p80.to_dict()
+
+        p90 = self.p90.to_dict()
+
+        p95 = self.p95.to_dict()
+
+        p99 = self.p99.to_dict()
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "timestamp": timestamp,
+            "prediction": prediction,
+            "p80": p80,
+            "p90": p90,
+            "p95": p95,
+            "p99": p99,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.probabilistic_circuit_rating_ampacity import ProbabilisticCircuitRatingAmpacity
+        d = dict(src_dict)
+        timestamp = isoparse(d.pop("timestamp"))
+
+
+
+
+        prediction = ProbabilisticCircuitRatingAmpacity.from_dict(d.pop("prediction"))
+
+
+
+
+        p80 = ProbabilisticCircuitRatingAmpacity.from_dict(d.pop("p80"))
+
+
+
+
+        p90 = ProbabilisticCircuitRatingAmpacity.from_dict(d.pop("p90"))
+
+
+
+
+        p95 = ProbabilisticCircuitRatingAmpacity.from_dict(d.pop("p95"))
+
+
+
+
+        p99 = ProbabilisticCircuitRatingAmpacity.from_dict(d.pop("p99"))
+
+
+
+
+        predicted_circuit_rating_forecast = cls(
+            timestamp=timestamp,
+            prediction=prediction,
+            p80=p80,
+            p90=p90,
+            p95=p95,
+            p99=p99,
+        )
+
+
+        predicted_circuit_rating_forecast.additional_properties = d
+        return predicted_circuit_rating_forecast
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/predicted_forecast.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/predicted_forecast.py
@@ -1,0 +1,139 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from dateutil.parser import isoparse
+from typing import cast
+import datetime
+
+if TYPE_CHECKING:
+  from ..models.probabilistic_line_ampacity import ProbabilisticLineAmpacity
+
+
+
+
+
+T = TypeVar("T", bound="PredictedForecast")
+
+
+
+@_attrs_define
+class PredictedForecast:
+    """ 
+        Attributes:
+            timestamp (datetime.datetime): Timestamp for the predicted forecast. Example: 2024-07-01T12:00:00.001Z.
+            prediction (ProbabilisticLineAmpacity):
+            p80 (ProbabilisticLineAmpacity):
+            p90 (ProbabilisticLineAmpacity):
+            p95 (ProbabilisticLineAmpacity):
+            p99 (ProbabilisticLineAmpacity):
+     """
+
+    timestamp: datetime.datetime
+    prediction: 'ProbabilisticLineAmpacity'
+    p80: 'ProbabilisticLineAmpacity'
+    p90: 'ProbabilisticLineAmpacity'
+    p95: 'ProbabilisticLineAmpacity'
+    p99: 'ProbabilisticLineAmpacity'
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        from ..models.probabilistic_line_ampacity import ProbabilisticLineAmpacity
+        timestamp = self.timestamp.isoformat()
+
+        prediction = self.prediction.to_dict()
+
+        p80 = self.p80.to_dict()
+
+        p90 = self.p90.to_dict()
+
+        p95 = self.p95.to_dict()
+
+        p99 = self.p99.to_dict()
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "timestamp": timestamp,
+            "prediction": prediction,
+            "p80": p80,
+            "p90": p90,
+            "p95": p95,
+            "p99": p99,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.probabilistic_line_ampacity import ProbabilisticLineAmpacity
+        d = dict(src_dict)
+        timestamp = isoparse(d.pop("timestamp"))
+
+
+
+
+        prediction = ProbabilisticLineAmpacity.from_dict(d.pop("prediction"))
+
+
+
+
+        p80 = ProbabilisticLineAmpacity.from_dict(d.pop("p80"))
+
+
+
+
+        p90 = ProbabilisticLineAmpacity.from_dict(d.pop("p90"))
+
+
+
+
+        p95 = ProbabilisticLineAmpacity.from_dict(d.pop("p95"))
+
+
+
+
+        p99 = ProbabilisticLineAmpacity.from_dict(d.pop("p99"))
+
+
+
+
+        predicted_forecast = cls(
+            timestamp=timestamp,
+            prediction=prediction,
+            p80=p80,
+            p90=p90,
+            p95=p95,
+            p99=p99,
+        )
+
+
+        predicted_forecast.additional_properties = d
+        return predicted_forecast
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/probabilistic_circuit_rating_ampacity.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/probabilistic_circuit_rating_ampacity.py
@@ -1,0 +1,114 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import cast, Union
+from typing import Union
+from uuid import UUID
+
+
+
+
+
+
+T = TypeVar("T", bound="ProbabilisticCircuitRatingAmpacity")
+
+
+
+@_attrs_define
+class ProbabilisticCircuitRatingAmpacity:
+    """ 
+        Attributes:
+            value (float): The ampacity value (in amperes) for the facility component id. Example: 375.4.
+            at_facility_component_id (Union[None, UUID, Unset]): Identifier of the facility component at which this ampacity
+                forecast was calculated. The forecast is computed per facility component and timestamp, and the final
+                dimensioning value is determined by selecting the facility component with the lowest ampacity. Example:
+                00000000-0000-0000-0000-000000000000.
+     """
+
+    value: float
+    at_facility_component_id: Union[None, UUID, Unset] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        value = self.value
+
+        at_facility_component_id: Union[None, Unset, str]
+        if isinstance(self.at_facility_component_id, Unset):
+            at_facility_component_id = UNSET
+        elif isinstance(self.at_facility_component_id, UUID):
+            at_facility_component_id = str(self.at_facility_component_id)
+        else:
+            at_facility_component_id = self.at_facility_component_id
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "value": value,
+        })
+        if at_facility_component_id is not UNSET:
+            field_dict["at_facility_component_id"] = at_facility_component_id
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        value = d.pop("value")
+
+        def _parse_at_facility_component_id(data: object) -> Union[None, UUID, Unset]:
+            if data is None:
+                return data
+            if isinstance(data, Unset):
+                return data
+            try:
+                if not isinstance(data, str):
+                    raise TypeError()
+                at_facility_component_id_type_0 = UUID(data)
+
+
+
+                return at_facility_component_id_type_0
+            except: # noqa: E722
+                pass
+            return cast(Union[None, UUID, Unset], data)
+
+        at_facility_component_id = _parse_at_facility_component_id(d.pop("at_facility_component_id", UNSET))
+
+
+        probabilistic_circuit_rating_ampacity = cls(
+            value=value,
+            at_facility_component_id=at_facility_component_id,
+        )
+
+
+        probabilistic_circuit_rating_ampacity.additional_properties = d
+        return probabilistic_circuit_rating_ampacity
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/probabilistic_line_ampacity.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/probabilistic_line_ampacity.py
@@ -1,0 +1,88 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from uuid import UUID
+
+
+
+
+
+
+T = TypeVar("T", bound="ProbabilisticLineAmpacity")
+
+
+
+@_attrs_define
+class ProbabilisticLineAmpacity:
+    """ 
+        Attributes:
+            value (float): The ampacity value (in amperes) for the line. Example: 375.4.
+            at_span_id (UUID): Identifier of the span at which this ampacity forecast was calculated. The forecast is
+                computed per span and timestamp, and the final dimensioning value is determined by selecting the span with the
+                lowest ampacity. Example: 00000000-0000-0000-0000-000000000000.
+     """
+
+    value: float
+    at_span_id: UUID
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        value = self.value
+
+        at_span_id = str(self.at_span_id)
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+            "value": value,
+            "at_span_id": at_span_id,
+        })
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        value = d.pop("value")
+
+        at_span_id = UUID(d.pop("at_span_id"))
+
+
+
+
+        probabilistic_line_ampacity = cls(
+            value=value,
+            at_span_id=at_span_id,
+        )
+
+
+        probabilistic_line_ampacity.additional_properties = d
+        return probabilistic_line_ampacity
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/problem_details.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/problem_details.py
@@ -1,0 +1,113 @@
+from collections.abc import Mapping
+from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+
+from attrs import define as _attrs_define
+from attrs import field as _attrs_field
+
+from ..types import UNSET, Unset
+
+from ..types import UNSET, Unset
+from typing import Union
+
+
+
+
+
+
+T = TypeVar("T", bound="ProblemDetails")
+
+
+
+@_attrs_define
+class ProblemDetails:
+    """ 
+        Attributes:
+            type_ (Union[Unset, str]):
+            title (Union[Unset, str]):
+            status (Union[Unset, int]):
+            detail (Union[Unset, str]):
+            instance (Union[Unset, str]):
+     """
+
+    type_: Union[Unset, str] = UNSET
+    title: Union[Unset, str] = UNSET
+    status: Union[Unset, int] = UNSET
+    detail: Union[Unset, str] = UNSET
+    instance: Union[Unset, str] = UNSET
+    additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
+
+
+
+
+
+    def to_dict(self) -> dict[str, Any]:
+        type_ = self.type_
+
+        title = self.title
+
+        status = self.status
+
+        detail = self.detail
+
+        instance = self.instance
+
+
+        field_dict: dict[str, Any] = {}
+        field_dict.update(self.additional_properties)
+        field_dict.update({
+        })
+        if type_ is not UNSET:
+            field_dict["type"] = type_
+        if title is not UNSET:
+            field_dict["title"] = title
+        if status is not UNSET:
+            field_dict["status"] = status
+        if detail is not UNSET:
+            field_dict["detail"] = detail
+        if instance is not UNSET:
+            field_dict["instance"] = instance
+
+        return field_dict
+
+
+
+    @classmethod
+    def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        d = dict(src_dict)
+        type_ = d.pop("type", UNSET)
+
+        title = d.pop("title", UNSET)
+
+        status = d.pop("status", UNSET)
+
+        detail = d.pop("detail", UNSET)
+
+        instance = d.pop("instance", UNSET)
+
+        problem_details = cls(
+            type_=type_,
+            title=title,
+            status=status,
+            detail=detail,
+            instance=instance,
+        )
+
+
+        problem_details.additional_properties = d
+        return problem_details
+
+    @property
+    def additional_keys(self) -> list[str]:
+        return list(self.additional_properties.keys())
+
+    def __getitem__(self, key: str) -> Any:
+        return self.additional_properties[key]
+
+    def __setitem__(self, key: str, value: Any) -> None:
+        self.additional_properties[key] = value
+
+    def __delitem__(self, key: str) -> None:
+        del self.additional_properties[key]
+
+    def __contains__(self, key: str) -> bool:
+        return key in self.additional_properties

--- a/python/heimdall_api_client/capacity_monitoring_api_client/py.typed
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/py.typed
@@ -1,0 +1,1 @@
+# Marker file for PEP 561

--- a/python/heimdall_api_client/capacity_monitoring_api_client/types.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/types.py
@@ -1,0 +1,53 @@
+""" Contains some shared types for properties """
+
+from collections.abc import Mapping, MutableMapping
+from http import HTTPStatus
+from typing import BinaryIO, Generic, Optional, TypeVar, Literal, Union, IO
+
+from attrs import define
+
+
+class Unset:
+    def __bool__(self) -> Literal[False]:
+        return False
+
+
+UNSET: Unset = Unset()
+
+# The types that `httpx.Client(files=)` can accept, copied from that library.
+FileContent = Union[IO[bytes], bytes, str]
+FileTypes = Union[
+    # (filename, file (or bytes), content_type)
+    tuple[Optional[str], FileContent, Optional[str]],
+    # (filename, file (or bytes), content_type, headers)
+    tuple[Optional[str], FileContent, Optional[str], Mapping[str, str]],
+]
+RequestFiles = list[tuple[str, FileTypes]]
+
+@define
+class File:
+    """ Contains information for file uploads """
+
+    payload: BinaryIO
+    file_name: Optional[str] = None
+    mime_type: Optional[str] = None
+
+    def to_tuple(self) -> FileTypes:
+        """ Return a tuple representation that httpx will accept for multipart/form-data """
+        return self.file_name, self.payload, self.mime_type
+
+
+T = TypeVar("T")
+
+
+@define
+class Response(Generic[T]):
+    """ A response from an endpoint """
+
+    status_code: HTTPStatus
+    content: bytes
+    headers: MutableMapping[str, str]
+    parsed: Optional[T]
+
+
+__all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]

--- a/python/heimdall_api_client/client.py
+++ b/python/heimdall_api_client/client.py
@@ -1,8 +1,11 @@
 import logging
 from typing import List, Optional
+from uuid import UUID
 from heimdall_api_client.auth import AuthService
-from heimdall_api_client.assets_api_client.api.assets import assets_v1_get_assets
+from heimdall_api_client.assets import get_assets
+from heimdall_api_client.capacity_monitoring import get_latest_heimdall_aar, get_latest_heimdall_arr_forecasts, get_latest_heimdall_dlr, get_latest_heimdall_dlr_forecasts
 from heimdall_api_client.assets_api_client.client import AuthenticatedClient
+
 
 
 class HeimdallApiClient:
@@ -37,14 +40,55 @@ class HeimdallApiClient:
     def _get_authenticated_client(self) -> AuthenticatedClient:
         token = self.auth_service.get_valid_token()
         return AuthenticatedClient(base_url=self.api_base_url, token=token)
+    
+    def _get_region(self) -> str:
+        return self.auth_service.get_region_from_token()
 
     def get_assets(self):
         """
         Returns the list of assets from the Assets API.
         """
-        client = self._get_authenticated_client()
-        response = assets_v1_get_assets.sync_detailed(client=client)
-        if response.status_code != 200:
-            self.logger.error(f"Failed to fetch assets: {response.status_code} {response.text}")
-            raise Exception(f"Error fetching assets: {response.status_code} {response.text}")
-        return response.parsed
+        return get_assets(
+            client=self._get_authenticated_client(), 
+            x_region=self._get_region()
+            )
+    
+    def get_latest_heimdall_dlr(self, line_id: UUID):
+        """
+        Returns the latest Heimdall DLR (Dynamic Line rating) data.
+        """
+        return get_latest_heimdall_dlr(
+            client=self._get_authenticated_client(),
+            line_id=line_id,
+            region=self._get_region()
+        )
+    
+    def get_latest_heimdall_aar(self, line_id: UUID):
+        """
+        Returns the latest Heimdall AAR (Available Ampacity Rating) data.
+        """
+        return get_latest_heimdall_aar(
+            client=self._get_authenticated_client(),
+            line_id=line_id,
+            region=self._get_region()
+        )
+    
+    def get_latest_heimdall_dlr_forecasts(self, line_id: UUID):
+        """
+        Returns the latest Heimdall DLR forecasts.
+        """
+        return get_latest_heimdall_dlr_forecasts(
+            client=self._get_authenticated_client(),
+            line_id=line_id,
+            region=self._get_region()
+        )
+    
+    def get_latest_heimdall_aar_forecasts(self, line_id: UUID):
+        """
+        Returns the latest Heimdall AAR forecasts.
+        """
+        return get_latest_heimdall_arr_forecasts(
+            client=self._get_authenticated_client(),
+            line_id=line_id,
+            region=self._get_region()
+        )


### PR DESCRIPTION
- Added `capacity_monitoring` module
- Refactored `HeimdallApiClient` to improve encapsulation and reuse of the authenticated client
- Region extraction logic for consistent header population (`x-region`)
- Added `examples/print_heimdall_dlr.py` showcasing Heimdall DLR and Heimdall DLR forecast capabilities
- Updated `__init__.py` file to expose public methods in a flatter and more import-friendly structure

These changes make the SDK easier to use and maintain.

Did not include the circuit rating features in this PR (it's big enough already). Also note that the code in the heimdall_api_client.capacity_monitoring folder is generated code