### PR TITLE
chore: remove Ruff exclude config and apply linting fixes

### DIFF
--- a/python/heimdall_api_client/assets_api_client/api/assets/assets_v1_get_assets.py
+++ b/python/heimdall_api_client/assets_api_client/api/assets/assets_v1_get_assets.py
@@ -4,15 +4,13 @@ from typing import Any, Optional, Union, cast
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response, UNSET
+from ...types import Response
 from ... import errors
 
 from ...models.assets_v1_get_assets_response_200 import AssetsV1GetAssetsResponse200
 from ...models.assets_v1_get_assets_x_region import AssetsV1GetAssetsXRegion
 from ...models.problem_details import ProblemDetails
-from ...types import UNSET, Unset
-from typing import cast
-from typing import Union
+from ...types import Unset
 
 
 

--- a/python/heimdall_api_client/assets_api_client/models/api_response.py
+++ b/python/heimdall_api_client/assets_api_client/models/api_response.py
@@ -1,10 +1,9 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
 
 

--- a/python/heimdall_api_client/assets_api_client/models/assets.py
+++ b/python/heimdall_api_client/assets_api_client/models/assets.py
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
-from typing import cast
 
 if TYPE_CHECKING:
   from ..models.grid_owner import GridOwner
@@ -34,7 +32,6 @@ class Assets:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.grid_owner import GridOwner
         grid_owners = []
         for grid_owners_item_data in self.grid_owners:
             grid_owners_item = grid_owners_item_data.to_dict()

--- a/python/heimdall_api_client/assets_api_client/models/assets_v1_get_assets_response_200.py
+++ b/python/heimdall_api_client/assets_api_client/models/assets_v1_get_assets_response_200.py
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
-from typing import cast
 
 if TYPE_CHECKING:
   from ..models.assets import Assets
@@ -34,7 +32,6 @@ class AssetsV1GetAssetsResponse200:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.assets import Assets
         data = self.data.to_dict()
 
 

--- a/python/heimdall_api_client/assets_api_client/models/facility.py
+++ b/python/heimdall_api_client/assets_api_client/models/facility.py
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
-from typing import cast
 from uuid import UUID
 
 if TYPE_CHECKING:
@@ -39,7 +37,6 @@ class Facility:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.line import Line
         id = str(self.id)
 
         name = self.name

--- a/python/heimdall_api_client/assets_api_client/models/grid_owner.py
+++ b/python/heimdall_api_client/assets_api_client/models/grid_owner.py
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
-from typing import cast
 
 if TYPE_CHECKING:
   from ..models.facility import Facility
@@ -36,7 +34,6 @@ class GridOwner:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.facility import Facility
         name = self.name
 
         facilities = []

--- a/python/heimdall_api_client/assets_api_client/models/line.py
+++ b/python/heimdall_api_client/assets_api_client/models/line.py
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
-from typing import cast
 from uuid import UUID
 
 if TYPE_CHECKING:
@@ -42,7 +40,6 @@ class Line:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.span import Span
         id = str(self.id)
 
         name = self.name

--- a/python/heimdall_api_client/assets_api_client/models/problem_details.py
+++ b/python/heimdall_api_client/assets_api_client/models/problem_details.py
@@ -1,12 +1,11 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-from ..types import UNSET, Unset
 from typing import Union
 
 

--- a/python/heimdall_api_client/assets_api_client/models/span.py
+++ b/python/heimdall_api_client/assets_api_client/models/span.py
@@ -1,13 +1,11 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-from ..types import UNSET, Unset
-from typing import cast
 from typing import Union
 from uuid import UUID
 
@@ -43,7 +41,6 @@ class Span:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.span_phase import SpanPhase
         id = str(self.id)
 
         span_phases = []

--- a/python/heimdall_api_client/assets_api_client/models/span_phase.py
+++ b/python/heimdall_api_client/assets_api_client/models/span_phase.py
@@ -1,12 +1,11 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-from ..types import UNSET, Unset
 from typing import Union
 from uuid import UUID
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/facility/capacity_monitoring_v1_facilities_get_latest_circuit_rating.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/facility/capacity_monitoring_v1_facilities_get_latest_circuit_rating.py
@@ -4,15 +4,13 @@ from typing import Any, Optional, Union, cast
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response, UNSET
+from ...types import Response
 from ... import errors
 
 from ...models.capacity_monitoring_v1_facilities_get_latest_circuit_rating_response_200 import CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200
 from ...models.capacity_monitoring_v1_facilities_get_latest_circuit_rating_x_region import CapacityMonitoringV1FacilitiesGetLatestCircuitRatingXRegion
 from ...models.problem_details import ProblemDetails
-from ...types import UNSET, Unset
-from typing import cast
-from typing import Union
+from ...types import Unset
 from uuid import UUID
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/facility/capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/facility/capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts.py
@@ -4,15 +4,13 @@ from typing import Any, Optional, Union, cast
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response, UNSET
+from ...types import Response
 from ... import errors
 
 from ...models.capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_response_200 import CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200
 from ...models.capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_x_region import CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsXRegion
 from ...models.problem_details import ProblemDetails
-from ...types import UNSET, Unset
-from typing import cast
-from typing import Union
+from ...types import Unset
 from uuid import UUID
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_aar.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_aar.py
@@ -4,15 +4,13 @@ from typing import Any, Optional, Union, cast
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response, UNSET
+from ...types import Response
 from ... import errors
 
 from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_aar_response_200 import CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200
 from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_aar_x_region import CapacityMonitoringV1LinesGetLatestHeimdallAarXRegion
 from ...models.problem_details import ProblemDetails
-from ...types import UNSET, Unset
-from typing import cast
-from typing import Union
+from ...types import Unset
 from uuid import UUID
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts.py
@@ -4,15 +4,13 @@ from typing import Any, Optional, Union, cast
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response, UNSET
+from ...types import Response
 from ... import errors
 
 from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_response_200 import CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200
 from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_x_region import CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsXRegion
 from ...models.problem_details import ProblemDetails
-from ...types import UNSET, Unset
-from typing import cast
-from typing import Union
+from ...types import Unset
 from uuid import UUID
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_dlr.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_dlr.py
@@ -4,15 +4,13 @@ from typing import Any, Optional, Union, cast
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response, UNSET
+from ...types import Response
 from ... import errors
 
 from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_dlr_response_200 import CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200
 from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_dlr_x_region import CapacityMonitoringV1LinesGetLatestHeimdallDlrXRegion
 from ...models.problem_details import ProblemDetails
-from ...types import UNSET, Unset
-from typing import cast
-from typing import Union
+from ...types import Unset
 from uuid import UUID
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/api/line/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts.py
@@ -4,15 +4,13 @@ from typing import Any, Optional, Union, cast
 import httpx
 
 from ...client import AuthenticatedClient, Client
-from ...types import Response, UNSET
+from ...types import Response
 from ... import errors
 
 from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_response_200 import CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200
 from ...models.capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_x_region import CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsXRegion
 from ...models.problem_details import ProblemDetails
-from ...types import UNSET, Unset
-from typing import cast
-from typing import Union
+from ...types import Unset
 from uuid import UUID
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/aar.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/aar.py
@@ -1,13 +1,11 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
 from dateutil.parser import isoparse
-from typing import cast
 import datetime
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/api_response.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/api_response.py
@@ -1,10 +1,9 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_response_200.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_response_200.py
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
-from typing import cast
 
 if TYPE_CHECKING:
   from ..models.circuit_rating_forecasts import CircuitRatingForecasts
@@ -34,7 +32,6 @@ class CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.circuit_rating_forecasts import CircuitRatingForecasts
         data = self.data.to_dict()
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_facilities_get_latest_circuit_rating_response_200.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_facilities_get_latest_circuit_rating_response_200.py
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
-from typing import cast
 
 if TYPE_CHECKING:
   from ..models.latest_circuit_rating import LatestCircuitRating
@@ -34,7 +32,6 @@ class CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.latest_circuit_rating import LatestCircuitRating
         data = self.data.to_dict()
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_response_200.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_response_200.py
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
-from typing import cast
 
 if TYPE_CHECKING:
   from ..models.heimdall_aar_forecasts import HeimdallAarForecasts
@@ -34,7 +32,6 @@ class CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.heimdall_aar_forecasts import HeimdallAarForecasts
         data = self.data.to_dict()
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_aar_response_200.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_aar_response_200.py
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
-from typing import cast
 
 if TYPE_CHECKING:
   from ..models.latest_aar import LatestAar
@@ -34,7 +32,6 @@ class CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.latest_aar import LatestAar
         data = self.data.to_dict()
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_response_200.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_response_200.py
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
-from typing import cast
 
 if TYPE_CHECKING:
   from ..models.heimdall_dlr_forecasts import HeimdallDlrForecasts
@@ -34,7 +32,6 @@ class CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.heimdall_dlr_forecasts import HeimdallDlrForecasts
         data = self.data.to_dict()
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_response_200.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/capacity_monitoring_v1_lines_get_latest_heimdall_dlr_response_200.py
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
-from typing import cast
 
 if TYPE_CHECKING:
   from ..models.latest_dlr import LatestDlr
@@ -34,7 +32,6 @@ class CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.latest_dlr import LatestDlr
         data = self.data.to_dict()
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/circuit_rating.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/circuit_rating.py
@@ -1,13 +1,11 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
 from dateutil.parser import isoparse
-from typing import cast
 import datetime
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/circuit_rating_forecasts.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/circuit_rating_forecasts.py
@@ -1,13 +1,11 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
 from dateutil.parser import isoparse
-from typing import cast
 import datetime
 
 if TYPE_CHECKING:
@@ -44,7 +42,6 @@ class CircuitRatingForecasts:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.predicted_circuit_rating_forecast import PredictedCircuitRatingForecast
         metric = self.metric
 
         unit = self.unit

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/dlr.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/dlr.py
@@ -1,13 +1,11 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
 from dateutil.parser import isoparse
-from typing import cast
 import datetime
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/heimdall_aar_forecasts.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/heimdall_aar_forecasts.py
@@ -1,13 +1,11 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
 from dateutil.parser import isoparse
-from typing import cast
 import datetime
 
 if TYPE_CHECKING:
@@ -44,7 +42,6 @@ class HeimdallAarForecasts:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.predicted_forecast import PredictedForecast
         metric = self.metric
 
         unit = self.unit

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/heimdall_dlr_forecasts.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/heimdall_dlr_forecasts.py
@@ -1,13 +1,11 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
 from dateutil.parser import isoparse
-from typing import cast
 import datetime
 
 if TYPE_CHECKING:
@@ -44,7 +42,6 @@ class HeimdallDlrForecasts:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.predicted_forecast import PredictedForecast
         metric = self.metric
 
         unit = self.unit

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/latest_aar.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/latest_aar.py
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
-from typing import cast
 
 if TYPE_CHECKING:
   from ..models.aar import Aar
@@ -38,7 +36,6 @@ class LatestAar:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.aar import Aar
         metric = self.metric
 
         unit = self.unit

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/latest_circuit_rating.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/latest_circuit_rating.py
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
-from typing import cast
 
 if TYPE_CHECKING:
   from ..models.circuit_rating import CircuitRating
@@ -38,7 +36,6 @@ class LatestCircuitRating:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.circuit_rating import CircuitRating
         metric = self.metric
 
         unit = self.unit

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/latest_dlr.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/latest_dlr.py
@@ -1,12 +1,10 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
-from typing import cast
 
 if TYPE_CHECKING:
   from ..models.dlr import Dlr
@@ -38,7 +36,6 @@ class LatestDlr:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.dlr import Dlr
         metric = self.metric
 
         unit = self.unit

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/predicted_circuit_rating_forecast.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/predicted_circuit_rating_forecast.py
@@ -1,13 +1,11 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
 from dateutil.parser import isoparse
-from typing import cast
 import datetime
 
 if TYPE_CHECKING:
@@ -46,7 +44,6 @@ class PredictedCircuitRatingForecast:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.probabilistic_circuit_rating_ampacity import ProbabilisticCircuitRatingAmpacity
         timestamp = self.timestamp.isoformat()
 
         prediction = self.prediction.to_dict()

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/predicted_forecast.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/predicted_forecast.py
@@ -1,13 +1,11 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar, TYPE_CHECKING
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
 from dateutil.parser import isoparse
-from typing import cast
 import datetime
 
 if TYPE_CHECKING:
@@ -46,7 +44,6 @@ class PredictedForecast:
 
 
     def to_dict(self) -> dict[str, Any]:
-        from ..models.probabilistic_line_ampacity import ProbabilisticLineAmpacity
         timestamp = self.timestamp.isoformat()
 
         prediction = self.prediction.to_dict()

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/probabilistic_circuit_rating_ampacity.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/probabilistic_circuit_rating_ampacity.py
@@ -1,14 +1,12 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-from ..types import UNSET, Unset
 from typing import cast, Union
-from typing import Union
 from uuid import UUID
 
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/probabilistic_line_ampacity.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/probabilistic_line_ampacity.py
@@ -1,10 +1,9 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-from ..types import UNSET, Unset
 
 from uuid import UUID
 

--- a/python/heimdall_api_client/capacity_monitoring_api_client/models/problem_details.py
+++ b/python/heimdall_api_client/capacity_monitoring_api_client/models/problem_details.py
@@ -1,12 +1,11 @@
 from collections.abc import Mapping
-from typing import Any, TypeVar, Optional, BinaryIO, TextIO, TYPE_CHECKING, Generator
+from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-from ..types import UNSET, Unset
 from typing import Union
 
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -18,9 +18,10 @@ ruff = "^0.12.3"
 [tool.ruff]
 line-length = 120
 target-version = "py311"
-extend-exclude = [
-    "heimdall_api_client/*_api_client", 
-    ]
+# Exclude generated API client files from linting
+# extend-exclude = [
+#     "heimdall_api_client/*_api_client", 
+#     ]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]


### PR DESCRIPTION
- Commented out the `extend-exclude` section in `pyproject.toml` to allow Ruff to lint all files, including generated API clients
- Applied `ruff --fix` to automatically correct formatting and linting issues across the SDK
- Generated files will now follow the same code quality standards as the rest of the SDK