### PR TITLE
Fix: Set correct working directory

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: dotnet/HeimdallPower.Api.Client
+        working-directory: dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Changes: 
Nuget publishing is failing due to wrong working directory, so this PR points to the correct path where the project file is.