### PR TITLE
POWER-3825: Generate documentation for when referencing nuget package

### DIFF
--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallPower.Api.Client.csproj
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallPower.Api.Client.csproj
@@ -3,6 +3,7 @@
     <PropertyGroup>
         <TargetFramework>net9.0</TargetFramework>
         <ImplicitUsings>enable</ImplicitUsings>
+        <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <Nullable>enable</Nullable>
         <PackageId>HeimdallPower.Api.Client</PackageId>
         <Version>0.0.0</Version> <!-- Placeholder, overridden in CI -->


### PR DESCRIPTION
Changes: 
- Added option of generating xml documentation for project, so that users of the nuget package can access the descriptions and examples in IDE.