### PR TITLE
ci: add python release pipeline

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -1,0 +1,55 @@
+name: Python Publish
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+
+    permissions:
+      contents: write # Required to upload release artifacts
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install Poetry
+        run: |
+          pip install poetry
+
+      - name: Validate tag format
+        run: |
+          if [[ ! "$GITHUB_REF_NAME" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[a-z0-9\.]+)?$ ]]; then
+            echo "Invalid tag format: $GITHUB_REF_NAME"
+            echo "Expected: v<MAJOR>.<MINOR>.<PATCH> (e.g., v1.2.3 or v1.2.3-beta.1)"
+            exit 1
+          fi
+
+      - name: Set version from tag
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo "Setting poetry version to $VERSION"
+          poetry version $VERSION
+
+      - name: Install dependencies
+        run: poetry install --no-root
+
+      - name: Build package
+        run: poetry build
+
+      - name: Upload dist artifacts to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            python/dist/*.whl

--- a/python/README.md
+++ b/python/README.md
@@ -16,6 +16,16 @@ curl -sSL https://install.python-poetry.org | python3 -
 poetry install
 ```
 
+### Installing the SDK
+
+The package can be downloaded and installed unsing the github relase artifacts
+
+```bash
+pip install https://github.com/heimdallpower/api-sdk/releases/download/v1.2.3/heimdall_api_sdk-1.2.3-py3-none-any.whl
+```
+
+> Replace the version and filename with the latest from [Releases](https://github.com/heimdallpower/api-sdk/releases)
+
 ### Usage Example
 
 ```python


### PR DESCRIPTION
adds pipeline for building and uploading Python package artifacts (.whl) to the GitHub Release that triggered the workflow.

The pipeline uses poetry similar to the build, and softprops/action-gh-release for attaching files to the release: https://github.com/softprops/action-gh-release?tab=readme-ov-file#%EF%B8%8F-uploading-release-assets.

substitute until we get the pypi org setup