### PR TITLE
feat: improve HeimdallApiHttpClient reliability and encapsulation

### DIFF
--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiClient.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiClient.cs
@@ -7,11 +7,12 @@ using HeimdallPower.Api.Client.GridInsights.Lines;
 namespace HeimdallPower.Api.Client;
 
 /// <summary>
-/// A client that lets you consume the Heimdall Power API
+/// A client that lets you consume the Heimdall Power API.
+/// Throws <see cref="HeimdallApiException"/> on errors.
 /// </summary>
-public class HeimdallApiClient(string clientId, string clientSecret)
+public class HeimdallApiClient(string clientId, string clientSecret, HttpClient? httpClient = null)
 {
-    private readonly HeimdallApiHttpClient _heimdallApiClient = new (clientId, clientSecret);
+    private readonly HeimdallApiHttpClient _heimdallApiClient = new(clientId, clientSecret, httpClient);
 
     /// <summary>
     /// Get a list of all lines associated with the grid owner.
@@ -19,10 +20,7 @@ public class HeimdallApiClient(string clientId, string clientSecret)
     public async Task<List<LineDto?>> GetLines()
     {
         var url = UrlBuilder.BuildAssetsUrl();
-        var response = await _heimdallApiClient.Get<ApiResponse<AssetsResponse>>(url);
-
-        if (response?.Data == null) return new List<LineDto?>();
-
+        var response = await _heimdallApiClient.GetAsync<ApiResponse<AssetsResponse>>(url);
         return response.Data.GridOwners
             .Where(go => go?.Facilities is { Count: > 0 })
             .SelectMany(go => go.Facilities
@@ -37,9 +35,7 @@ public class HeimdallApiClient(string clientId, string clientSecret)
     public async Task<List<FacilityDto>> GetFacilities()
     {
         var url = UrlBuilder.BuildAssetsUrl();
-        var response = await _heimdallApiClient.Get<ApiResponse<AssetsResponse>>(url);
-
-        if (response?.Data == null) return new List<FacilityDto>();
+        var response = await _heimdallApiClient.GetAsync<ApiResponse<AssetsResponse>>(url);
 
         return response.Data.GridOwners
             .Where(go => go?.Facilities is { Count: > 0 })
@@ -53,12 +49,12 @@ public class HeimdallApiClient(string clientId, string clientSecret)
     /// The current is aggregated across the entire line using a 5-minute sliding window, where the maximum value is calculated for each window.
     /// </summary>
     /// <param name="lineId">Id of the line for which to retrieve the latest current.</param>
-    public async Task<LatestCurrentResponse?> GetLatestCurrent(Guid lineId)
+    public async Task<LatestCurrentResponse> GetLatestCurrent(Guid lineId)
     {
         var url = UrlBuilder.BuildLatestCurrentsUrl(lineId);
-        var response = await _heimdallApiClient.Get<ApiResponse<LatestCurrentResponse>>(url);
+        var response = await _heimdallApiClient.GetAsync<ApiResponse<LatestCurrentResponse>>(url);
 
-        return response?.Data;
+        return response.Data;
     }
 
     /// <summary>
@@ -68,11 +64,11 @@ public class HeimdallApiClient(string clientId, string clientSecret)
     /// </summary>
     /// <param name="lineId">Id of the line for which to retrieve the latest conductor temperature.</param>
     /// <param name="unitSystem">The unit system for response values. "metric" gives values in Celsius (C), while "imperial" gives values in Fahrenheit (F). Defaults to metric if not specified.</param>
-    public async Task<LatestConductorTemperatureResponse?> GetLatestConductorTemperature(Guid lineId, string unitSystem = "metric")
+    public async Task<LatestConductorTemperatureResponse> GetLatestConductorTemperature(Guid lineId, string unitSystem = "metric")
     {
         var url = UrlBuilder.BuildLatestConductorTemperatureUrl(lineId, unitSystem);
-        var response = await _heimdallApiClient.Get<ApiResponse<LatestConductorTemperatureResponse>>(url);
-        return response?.Data;
+        var response = await _heimdallApiClient.GetAsync<ApiResponse<LatestConductorTemperatureResponse>>(url);
+        return response.Data;
     }
 
     /// <summary>
@@ -82,12 +78,12 @@ public class HeimdallApiClient(string clientId, string clientSecret)
     /// Heimdall DLR is aggregated over the entire line. Using a 5-minute sliding window, the minimum ampacity is calculated for each window.
     /// </summary>
     /// <param name="lineId">Id of the line for which to retrieve the latest Heimdall DLR.</param>
-    public async Task<LatestHeimdallDlrResponse?> GetLatestHeimdallDlr(Guid lineId)
+    public async Task<LatestHeimdallDlrResponse> GetLatestHeimdallDlr(Guid lineId)
     {
         var url = UrlBuilder.BuildHeimdallDlrUrl(lineId);
-        var response = await _heimdallApiClient.Get<ApiResponse<LatestHeimdallDlrResponse>>(url);
+        var response = await _heimdallApiClient.GetAsync<ApiResponse<LatestHeimdallDlrResponse>>(url);
 
-        return response?.Data;
+        return response.Data;
     }
 
     /// <summary>
@@ -97,12 +93,12 @@ public class HeimdallApiClient(string clientId, string clientSecret)
     /// Heimdall AAR is aggregated over the entire line. Using a 5-minute sliding window, the minimum ampacity is calculated for each window.
     /// </summary>
     /// <param name="lineId">Id of the line for which to retrieve the latest Heimdall AAR.</param>
-    public async Task<LatestHeimdallAarResponse?> GetLatestHeimdallAar(Guid lineId)
+    public async Task<LatestHeimdallAarResponse> GetLatestHeimdallAar(Guid lineId)
     {
         var url = UrlBuilder.BuildHeimdallAarUrl(lineId);
-        var response = await _heimdallApiClient.Get<ApiResponse<LatestHeimdallAarResponse>>(url);
+        var response = await _heimdallApiClient.GetAsync<ApiResponse<LatestHeimdallAarResponse>>(url);
 
-        return response?.Data;
+        return response.Data;
     }
 
     /// <summary>
@@ -112,12 +108,12 @@ public class HeimdallApiClient(string clientId, string clientSecret)
     /// For each unique timestamp and confidence level, we pick the value from the span which has the lowest ampacity value as this will be the dimensioning value for the line.
     /// </summary>
     /// <param name="lineId">Id of the line for which to retrieve Heimdall DLR forecasts.</param>
-    public async Task<HeimdallDlrForecastResponse?> GetHeimdallDlrForecasts(Guid lineId)
+    public async Task<HeimdallDlrForecastResponse> GetHeimdallDlrForecasts(Guid lineId)
     {
         var url = UrlBuilder.BuildDlrForecastUrl(lineId);
-        var response = await _heimdallApiClient.Get<ApiResponse<HeimdallDlrForecastResponse>>(url);
+        var response = await _heimdallApiClient.GetAsync<ApiResponse<HeimdallDlrForecastResponse>>(url);
 
-        return response?.Data;
+        return response.Data;
     }
 
     /// <summary>
@@ -127,12 +123,12 @@ public class HeimdallApiClient(string clientId, string clientSecret)
     /// For each unique timestamp and confidence level, we pick the value from the span which has the lowest ampacity value as this will be the dimensioning value for the line.
     /// </summary>
     /// <param name="lineId">Id of the line for which to retrieve Heimdall AAR forecasts.</param>
-    public async Task<HeimdallAarForecastResponse?> GetHeimdallAarForecasts(Guid lineId)
+    public async Task<HeimdallAarForecastResponse> GetHeimdallAarForecasts(Guid lineId)
     {
         var url = UrlBuilder.BuildAarForecastUrl(lineId);
-        var response = await _heimdallApiClient.Get<ApiResponse<HeimdallAarForecastResponse>>(url);
+        var response = await _heimdallApiClient.GetAsync<ApiResponse<HeimdallAarForecastResponse>>(url);
 
-        return response?.Data;
+        return response.Data;
     }
 
     /// <summary>
@@ -141,12 +137,12 @@ public class HeimdallApiClient(string clientId, string clientSecret)
     /// and are provided in 1-hour intervals.
     /// </summary>
     /// <param name="facilityId">Id of the facility for which to retrieve circuit rating forecasts.</param>
-    public async Task<CircuitRatingForecastResponse?> GetCircuitRatingForecasts(Guid facilityId)
+    public async Task<CircuitRatingForecastResponse> GetCircuitRatingForecasts(Guid facilityId)
     {
         var url = UrlBuilder.BuildCircuitRatingForecastUrl(facilityId);
-        var response = await _heimdallApiClient.Get<ApiResponse<CircuitRatingForecastResponse>>(url);
+        var response = await _heimdallApiClient.GetAsync<ApiResponse<CircuitRatingForecastResponse>>(url);
 
-        return response?.Data;
+        return response.Data;
     }
 
     /// <summary>
@@ -155,11 +151,11 @@ public class HeimdallApiClient(string clientId, string clientSecret)
     /// and are provided in 1-hour intervals.
     /// </summary>
     /// <param name="facilityId">Id of the facility for which to retrieve circuit rating forecasts.</param>
-    public async Task<LatestCircuitRatingResponse?> GetLatestCircuitRating(Guid facilityId)
+    public async Task<LatestCircuitRatingResponse> GetLatestCircuitRating(Guid facilityId)
     {
         var url = UrlBuilder.BuildCircuitRatingUrl(facilityId);
-        var response = await _heimdallApiClient.Get<ApiResponse<LatestCircuitRatingResponse>>(url);
+        var response = await _heimdallApiClient.GetAsync<ApiResponse<LatestCircuitRatingResponse>>(url);
 
-        return response?.Data;
+        return response.Data;
     }
 }

--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiException.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiException.cs
@@ -1,0 +1,30 @@
+using System.Net;
+
+namespace HeimdallPower.Api.Client;
+
+public class HeimdallApiException : Exception
+{
+    public HttpStatusCode StatusCode { get; }
+
+    public HeimdallApiException(string message, HttpStatusCode statusCode, string requestUrl = "")
+        : base(message)
+    {
+        StatusCode = statusCode;
+        base.Data["RequestUrl"] = requestUrl;
+    }
+
+    public HeimdallApiException(ProblemDetails problemDetails, HttpStatusCode statusCode, string requestUrl = "")
+        : base(problemDetails.Detail ?? "An error occurred while processing the request.")
+    {
+        StatusCode = statusCode;
+        base.Data["RequestUrl"] = requestUrl;
+        base.Data["Title"] = problemDetails.Title;
+        base.Data["Instance"] = problemDetails.Instance;
+        base.Data["Type"] = problemDetails.Type;
+        if (problemDetails.Errors == null) return;
+        foreach (var error in problemDetails.Errors)
+        {
+            base.Data[error.Key] = error.Value;
+        }
+    }
+}

--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiHttpClient.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiHttpClient.cs
@@ -32,6 +32,7 @@ internal class HeimdallApiHttpClient(string clientId, string clientSecret, HttpC
     private const string Authority = $"{Instance}/tfp/{Domain}/{Policy}";
 
     private DateTimeOffset _tokenExpiresOn = default;
+    private static readonly TimeSpan TokenExpirationBuffer = TimeSpan.FromMinutes(2);
 
     public async Task<T> GetAsync<T>(string url)
     {

--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiHttpClient.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiHttpClient.cs
@@ -86,7 +86,7 @@ internal class HeimdallApiHttpClient(string clientId, string clientSecret, HttpC
 
     private async Task UpdateAccessTokenIfExpired()
     {
-        if (_tokenExpiresOn == default || DateTimeOffset.UtcNow.AddMinutes(2) > _tokenExpiresOn)
+        if (_tokenExpiresOn == default || DateTimeOffset.UtcNow.Add(TokenExpirationBuffer) > _tokenExpiresOn)
         {
             await RefreshAccessToken();
         }

--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiHttpClient.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiHttpClient.cs
@@ -1,13 +1,16 @@
 ﻿using System.IdentityModel.Tokens.Jwt;
+using System.Net;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using Microsoft.Identity.Client;
 
 namespace HeimdallPower.Api.Client;
 
-public class HeimdallApiHttpClient(string clientId, string clientSecret)
+internal class HeimdallApiHttpClient(string clientId, string clientSecret, HttpClient? httpClient = null)
 {
-    private HttpClient HttpClient { get; } = new() { BaseAddress = new Uri(ApiUrl) };
+    private HttpClient HttpClient { get; } = httpClient ?? new() { BaseAddress = new Uri(ApiUrl) };
+
+    private readonly SemaphoreSlim _tokenLock = new(1, 1);
 
     private readonly IConfidentialClientApplication _msalClient = ConfidentialClientApplicationBuilder.Create(clientId)
         .WithClientSecret(clientSecret)
@@ -28,28 +31,71 @@ public class HeimdallApiHttpClient(string clientId, string clientSecret)
     private const string Scope = $"https://{Domain}/dc5758ae-4eea-416e-9e61-812914d9a49a/.default";
     private const string Authority = $"{Instance}/tfp/{Domain}/{Policy}";
 
-    private DateTimeOffset _tokenExpiresOn;
+    private DateTimeOffset _tokenExpiresOn = default;
 
-
-    public async Task<T?> Get<T>(string url)
+    public async Task<T> GetAsync<T>(string url)
     {
-        await UpdateAccessTokenIfExpired();
-        var response = await HttpClient.GetAsync(url);
-        var jsonString = await response.Content.ReadAsStringAsync();
+        return await ExecuteWithAuthRetry(async () =>
+        {
+            var response = await HttpClient.GetAsync(url);
+            var jsonString = await HandleResponse(response);
+            return JsonSerializer.Deserialize<T>(jsonString, _jsonSerializerOptions)
+                   ?? throw new HeimdallApiException("Failed to deserialize response.", response.StatusCode, url);
+        });
+    }
+
+    private static async Task<string> HandleResponse(HttpResponseMessage response)
+    {
+        var content = await response.Content.ReadAsStringAsync();
+
+        if (response.StatusCode == HttpStatusCode.Unauthorized)
+        {
+            throw new UnauthorizedAccessException("Unauthorized access. Please check your credentials.");
+        }
 
         if (response.IsSuccessStatusCode)
         {
-            var result = JsonSerializer.Deserialize<T>(jsonString, _jsonSerializerOptions);
-            return result;
+            return content;
         }
+        if (response.StatusCode == HttpStatusCode.BadRequest ||
+            response.StatusCode == HttpStatusCode.InternalServerError ||
+            response.StatusCode == HttpStatusCode.ServiceUnavailable)
+        {
+            var problem = JsonSerializer.Deserialize<ProblemDetails>(content)
+                ?? new ProblemDetails { Detail = "An error occurred while processing the request." };
+            throw new HeimdallApiException(problem, response.StatusCode, response.RequestMessage?.RequestUri?.ToString() ?? string.Empty);
+        }
+        throw new HeimdallApiException($"Request failed with status code {response.StatusCode}: {content}", response.StatusCode, response.RequestMessage?.RequestUri?.ToString() ?? string.Empty);
+    }
 
-        Console.WriteLine($"Request failed with status code: {response.StatusCode}, response: {jsonString}");
-        return default;
+
+
+    private async Task<T> ExecuteWithAuthRetry<T>(Func<Task<T>> operationFunc)
+    {
+        try
+        {
+            await UpdateAccessTokenIfExpired();
+            return await operationFunc();
+        }
+        catch (UnauthorizedAccessException)
+        {
+            await RefreshAccessToken();
+            return await operationFunc();
+        }
     }
 
     private async Task UpdateAccessTokenIfExpired()
     {
-        if (DateTimeOffset.UtcNow > _tokenExpiresOn)
+        if (_tokenExpiresOn == default || DateTimeOffset.UtcNow.AddMinutes(2) > _tokenExpiresOn)
+        {
+            await RefreshAccessToken();
+        }
+    }
+
+    private async Task RefreshAccessToken()
+    {
+        await _tokenLock.WaitAsync();
+        try
         {
             var authenticationResult = await _msalClient.AcquireTokenForClient([Scope]).ExecuteAsync();
             var handler = new JwtSecurityTokenHandler();
@@ -58,6 +104,10 @@ public class HeimdallApiHttpClient(string clientId, string clientSecret)
             HttpClient.DefaultRequestHeaders.Add("x-region", region);
             _tokenExpiresOn = authenticationResult.ExpiresOn;
             HttpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", authenticationResult.AccessToken);
+        }
+        finally
+        {
+            _tokenLock.Release();
         }
     }
 }

--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiHttpClient.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiHttpClient.cs
@@ -94,7 +94,7 @@ internal class HeimdallApiHttpClient(string clientId, string clientSecret, HttpC
 
     private async Task RefreshAccessToken()
     {
-        await _tokenLock.WaitAsync();
+        await _tokenLock.WaitAsync(TimeSpan.FromSeconds(30));
         try
         {
             var authenticationResult = await _msalClient.AcquireTokenForClient([Scope]).ExecuteAsync();

--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/ProblemDetails.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/ProblemDetails.cs
@@ -1,0 +1,10 @@
+﻿namespace HeimdallPower.Api.Client;
+
+public class ProblemDetails
+{
+    public string? Title { get; init; }
+    public string? Detail { get; init; }
+    public string? Instance { get; init; }
+    public string? Type { get; init; }
+    public IDictionary<string, string[]>? Errors { get; init; }
+}


### PR DESCRIPTION
- Made HeimdallApiHttpClient internal to enforce encapsulation and guide consumers to use HeimdallApiClient
- Added resiliency logic to retry once on 401 Unauthorized responses with a forced token refresh
- Introduced a 2-minute token expiration buffer to avoid edge-case expiry during requests
- Replaced Console.WriteLine output with proper exception throwing on non-success status codes
- Optionally exposed HttpClient via constructor to allow consumers to inject a custom resiliency pipeline (e.g., with Polly)