### PR TITLE
feat (POWER-3877 ): add support for custom client metadata headers in SDK requests

### DIFF
--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client.Extensions/HeimdallApiClientExtensions.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client.Extensions/HeimdallApiClientExtensions.cs
@@ -35,7 +35,7 @@ public static class HeimdallApiClientExtensions
             var httpClientFactory = sp.GetRequiredService<IHttpClientFactory>();
             var httpClient = httpClientFactory.CreateClient(clientName);
 
-            return new HeimdallApiClient(options.ClientId, options.ClientSecret, httpClient);
+            return new HeimdallApiClient(options.ClientId, options.ClientSecret, httpClient, options.ClientMetadata);
         });
 
         return services;

--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client.Extensions/HeimdallApiClientOptions.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client.Extensions/HeimdallApiClientOptions.cs
@@ -14,4 +14,9 @@ public class HeimdallApiClientOptions
     /// The client secret for the Heimdall Power API.
     /// </summary>
     public required string ClientSecret { get; init; }
+
+    /// <summary>
+    /// Additional metadata to include in the request headers.
+    /// </summary>
+    public Dictionary<string, string>? ClientMetadata { get; init; }
 }

--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiClient.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiClient.cs
@@ -10,9 +10,9 @@ namespace HeimdallPower.Api.Client;
 /// A client that lets you consume the Heimdall Power API.
 /// Throws <see cref="HeimdallApiException"/> on errors.
 /// </summary>
-public class HeimdallApiClient(string clientId, string clientSecret, HttpClient? httpClient = null)
+public class HeimdallApiClient(string clientId, string clientSecret, HttpClient? httpClient = null, Dictionary<string, string>? clientMetadata = null)
 {
-    private readonly HeimdallApiHttpClient _heimdallApiClient = new(clientId, clientSecret, httpClient);
+    private readonly HeimdallApiHttpClient _heimdallApiClient = new(clientId, clientSecret, httpClient, clientMetadata);
 
     /// <summary>
     /// Get all assets.

--- a/python/heimdall_api_client/client.py
+++ b/python/heimdall_api_client/client.py
@@ -21,8 +21,9 @@ class HeimdallApiClient:
         auth_policy: str = "b2c_1a_clientcredentialsflow",
         tenant: str = "hpadb2cprod",
         auth_authority_domain: str = "hpadb2cprod.b2clogin.com",
-        auth_scope: Optional[List[str]] = None,
-        logger: Optional[logging.Logger] = None,
+        auth_scope: Optional[List[str]] | None = None,
+        logger: Optional[logging.Logger] | None = None,
+        client_metadata: dict[str, str] | None = None
     ):
         self.logger = logger or logging.getLogger(__name__)
 
@@ -37,9 +38,17 @@ class HeimdallApiClient:
 
         self.api_base_url = api_base_url
 
+        default_metadata = {
+            "x-client-name": "python-sdk",
+            "x-client-version": "0.0.0",
+        }
+
+        # Ensure user values override the defaults
+        self.client_metadata = {**default_metadata, **(client_metadata or {})}
+
     def _get_authenticated_client(self) -> AuthenticatedClient:
         token = self.auth_service.get_valid_token()
-        return AuthenticatedClient(base_url=self.api_base_url, token=token)
+        return AuthenticatedClient(base_url=self.api_base_url, token=token, headers=self.client_metadata)
     
     def _get_region(self) -> str:
         return self.auth_service.get_region_from_token()


### PR DESCRIPTION
- Added optional clientMetadata parameter to HeimdallApiClient
- Injects headers x-client-name, x-client-version, etc. into all outgoing requests
- Allows consumers (e.g., SCADA connector) to identify themselves and their version
- Default values for x-client-name and x-client-version