### PR TITLE
chore(python): add format check, return types, and improve contributing docs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,7 +10,7 @@ indent_size = 4
 trim_trailing_whitespace = true
 insert_final_newline = true
 end_of_line = crlf
-charset = utf-8 bom
+charset = utf-8
 
 # C# files
 [*.cs]

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: "3.11"
 
@@ -47,6 +47,9 @@ jobs:
 
       - name: Lint code
         run: poetry run ruff check .
+
+      - name: Check formatting
+        run: poetry run ruff format --check .
 
       - name: Build package
         run: poetry build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ This repository contains SDKs and example clients for accessing the [Heimdall Po
 - Include a short description of what the PR does and why.
 - Pull requests targeting `main` must be reviewed by a **code owner**.
 
-> Heimdall Power's software engineering team (`@heimdallpower/software-engineering`) is configured as the code owner. Reviews will be automatically requested when a PR is opened.
+> Heimdall Power's backend team (`@heimdallpower/backend`) is configured as the code owner. Reviews will be automatically requested when a PR is opened.
 ---
 
 ## Branching & Releases
@@ -29,6 +29,12 @@ This repository contains SDKs and example clients for accessing the [Heimdall Po
 
 The `python/` folder contains the Python SDK and related utilities.
 
+> **Note:** The `*_api_client` subdirectories under `python/heimdall_api_client/`
+> (e.g., `assets_api_client`, `capacity_monitoring_api_client`, `grid_insights_api_client`)
+> are **auto-generated** from OpenAPI specs. Do not edit these directly — regenerate
+> them using the generation script instead. These directories are excluded from ruff
+> linting and formatting.
+
 ### Requirements
 
 - Python 3.11+
@@ -38,28 +44,35 @@ Install dependencies:
 
 ```bash
 curl -sSL https://install.python-poetry.org | python3 -
-
-poetry --version 
-
-poetry install --with dev # Installs the dependecies
+poetry --version
+poetry install --with dev
 ```
 
 #### Update dependencies
 
 ```bash
-poetry update --dry-run # view avaiables dependency updates
-poetry update # updates all dependecies. Note, does not alter the pyproject.toml file
+poetry update --dry-run  # View available dependency updates
+poetry update            # Update all dependencies (does not alter pyproject.toml)
 ```
 
 ### Code Style & Linting
 
-We use Ruff for formatting and linting.
+We use [Ruff](https://docs.astral.sh/ruff/) for both linting and formatting.
 
 ```bash
-poetry run ruff check . --fix 
-
-poetry run ruff formate .
+poetry run ruff check . --fix     # Lint and auto-fix
+poetry run ruff format .          # Format code
+poetry run ruff format --check .  # Check formatting (used in CI)
 ```
+
+### Testing
+
+```bash
+poetry run pytest                     # Run all non-integration tests
+poetry run pytest -m integration      # Run integration tests (requires credentials)
+```
+
+Integration tests require `HEIMDALL_CLIENT_ID` and `HEIMDALL_CLIENT_SECRET` environment variables.
 
 ### Building the Package
 
@@ -72,7 +85,7 @@ poetry build
 ```
 
 This will produce .whl and .tar.gz files.
->Running poetry build locally is recommended to catch issues early, such as missing ```__init__.py``` files, bad version strings, or invalid metadata.
+> Running poetry build locally is recommended to catch issues early, such as missing `__init__.py` files, bad version strings, or invalid metadata.
 
 ### Generating Clients from OpenAPI
 
@@ -81,7 +94,7 @@ New modules are generated using openapi-python-client.
 To generate a module:
 
 ```bash
-# Nagivate to the script folder and run
+# Navigate to the script folder and run
 ./generate_module.ps1 -Module assets
 ```
 
@@ -90,3 +103,24 @@ This will:
 - Download the OpenAPI spec
 - Generate a python client for the module
 - Place the result under `python/heimdall_api_client/<module>`
+
+---
+
+## .NET
+
+The `dotnet/` folder contains the .NET SDK.
+
+### Project Structure
+
+- `HeimdallPower.Api.Client` — Core SDK library
+- `HeimdallPower.Api.Client.Extensions` — DI integration and resilience extensions
+- `tests/` — Unit and integration tests
+
+### Running Tests
+
+```bash
+dotnet test --filter Category=Unit          # Unit tests only
+dotnet test --filter Category=Integration   # Integration tests (requires credentials)
+```
+
+Integration tests require `HEIMDALL_CLIENT_ID` and `HEIMDALL_CLIENT_SECRET` environment variables.

--- a/python/examples/print_assets.py
+++ b/python/examples/print_assets.py
@@ -1,6 +1,7 @@
-from heimdall_api_client.client import HeimdallApiClient
 import logging
 import pprint
+
+from heimdall_api_client.client import HeimdallApiClient
 
 logging.basicConfig(level=logging.WARN)
 

--- a/python/examples/print_circuit_rating.py
+++ b/python/examples/print_circuit_rating.py
@@ -1,4 +1,5 @@
 import logging
+
 from heimdall_api_client.client import HeimdallApiClient
 
 logging.basicConfig(level=logging.WARN)
@@ -24,9 +25,8 @@ for facility in grid_owner.facilities:
         print(f"Facility: {facility.name}")
         print(f"    {circuit_rating_response.data.metric}, timestamp {circuit_rating.timestamp}\n")
         print(f"        {circuit_rating.value} {circuit_rating_response.data.unit}, limited by {limiting_component}\n")
-        print(
-            f"    {circuit_rating_forecast_response.data.metric}, updated at {circuit_rating_forecast_response.data.updated_timestamp}:"
-        )
+        forecast_data = circuit_rating_forecast_response.data
+        print(f"    {forecast_data.metric}, updated at {forecast_data.updated_timestamp}:")
         for forecast in circuit_rating_forecast:
             print(
                 f"      {forecast.timestamp}: {forecast.prediction.value} {circuit_rating_forecast_response.data.unit}"

--- a/python/examples/print_conductor_temp_and_current.py
+++ b/python/examples/print_conductor_temp_and_current.py
@@ -1,4 +1,5 @@
 import logging
+
 from heimdall_api_client.client import HeimdallApiClient
 
 logging.basicConfig(level=logging.WARN)
@@ -27,12 +28,8 @@ for facility in grid_owner.facilities:
     latest_current_response = client.get_latest_current(line_id=line_id)
     latest_current = latest_current_response.data.current
 
-    print(
-        f"  Max Conductor Temperature, {latest_conductor_temp.timestamp}: {latest_conductor_temp.max_} {latest_conductor_temperature_response.data.unit}"
-    )
-    print(
-        f"  Min Conductor Temperature, {latest_conductor_temp.timestamp}: {latest_conductor_temp.min_} {latest_conductor_temperature_response.data.unit}"
-    )
-    print(
-        f"  Current,                   {latest_current.timestamp}: {latest_current.value} {latest_current_response.data.unit}"
-    )
+    temp_unit = latest_conductor_temperature_response.data.unit
+    current_unit = latest_current_response.data.unit
+    print(f"  Max Conductor Temperature, {latest_conductor_temp.timestamp}: {latest_conductor_temp.max_} {temp_unit}")
+    print(f"  Min Conductor Temperature, {latest_conductor_temp.timestamp}: {latest_conductor_temp.min_} {temp_unit}")
+    print(f"  Current,                   {latest_current.timestamp}: {latest_current.value} {current_unit}")

--- a/python/examples/print_heimdall_dlr.py
+++ b/python/examples/print_heimdall_dlr.py
@@ -1,4 +1,5 @@
 import logging
+
 from heimdall_api_client.client import HeimdallApiClient
 
 logging.basicConfig(level=logging.WARN)

--- a/python/examples/print_latest_icing.py
+++ b/python/examples/print_latest_icing.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta
 
 from heimdall_api_client.client import HeimdallApiClient
 
@@ -24,19 +24,14 @@ for facility in grid_owner.facilities:
     line_id = line.id
     print(f"Line: {line.name} (ID: {line_id})")
 
-    since = datetime.now(timezone.utc) - timedelta(minutes=30)
+    since = datetime.now(UTC) - timedelta(minutes=30)
     latest_icing_response = client.get_latest_icing(line_id=line_id, since=since)
     latest_icing = latest_icing_response.data.icing
 
     max_icing = latest_icing.max_
-    print(
-        f"  Max Ice Weight: {max_icing.ice_weight.value} {max_icing.ice_weight.unit} (span phase {max_icing.ice_weight.span_phase_id}, {max_icing.ice_weight.timestamp})"
-    )
-    print(
-        f"  Max Tension:    {max_icing.tension.value} {max_icing.tension.unit} (span phase {max_icing.tension.span_phase_id}, {max_icing.tension.timestamp})"
-    )
-    print(
-        "  Max Tension %:  "
-        f"{max_icing.tension_percentage_of_break_strength.value} {max_icing.tension_percentage_of_break_strength.unit} "
-        f"(span phase {max_icing.tension_percentage_of_break_strength.span_phase_id}, {max_icing.tension_percentage_of_break_strength.timestamp})"
-    )
+    iw = max_icing.ice_weight
+    tn = max_icing.tension
+    tp = max_icing.tension_percentage_of_break_strength
+    print(f"  Max Ice Weight: {iw.value} {iw.unit} (span phase {iw.span_phase_id}, {iw.timestamp})")
+    print(f"  Max Tension:    {tn.value} {tn.unit} (span phase {tn.span_phase_id}, {tn.timestamp})")
+    print(f"  Max Tension %:  {tp.value} {tp.unit} (span phase {tp.span_phase_id}, {tp.timestamp})")

--- a/python/examples/print_token.py
+++ b/python/examples/print_token.py
@@ -1,4 +1,5 @@
 import logging
+
 from heimdall_api_client.auth import AuthService
 
 logging.basicConfig(level=logging.WARN)

--- a/python/heimdall_api_client/assets.py
+++ b/python/heimdall_api_client/assets.py
@@ -1,8 +1,11 @@
 from heimdall_api_client.assets_api_client.api.assets import assets_v1_get_assets
 from heimdall_api_client.assets_api_client.client import AuthenticatedClient
+from heimdall_api_client.assets_api_client.models.assets_v1_get_assets_response_200 import (
+    AssetsV1GetAssetsResponse200,
+)
 
 
-def get_assets(client: AuthenticatedClient, x_region: str):
+def get_assets(client: AuthenticatedClient, x_region: str) -> AssetsV1GetAssetsResponse200:
     response = assets_v1_get_assets.sync_detailed(client=client, x_region=x_region)
     if response.status_code != 200:
         raise Exception(f"Error fetching assets: {response.status_code} {response.text}")

--- a/python/heimdall_api_client/auth.py
+++ b/python/heimdall_api_client/auth.py
@@ -1,8 +1,8 @@
 import logging
-import requests
-import jwt
 from datetime import datetime, timedelta
-from typing import List, Optional
+
+import jwt
+import requests
 
 
 class AuthService:
@@ -18,8 +18,8 @@ class AuthService:
         auth_policy: str = "b2c_1a_clientcredentialsflow",
         tenant: str = "hpadb2cprod",
         authority_domain: str = "hpadb2cprod.b2clogin.com",
-        scope: Optional[List[str]] = None,
-        logger: Optional[logging.Logger] = None,
+        scope: list[str] | None = None,
+        logger: logging.Logger | None = None,
     ):
         if not client_id or not client_secret:
             raise ValueError("client_id and client_secret must be provided")
@@ -33,8 +33,8 @@ class AuthService:
         self.token_url = (
             f"https://{self.authority_domain}/{self.tenant}.onmicrosoft.com/{self.auth_policy}/oauth2/v2.0/token"
         )
-        self._access_token: Optional[str] = None
-        self._expires_at: Optional[datetime] = None
+        self._access_token: str | None = None
+        self._expires_at: datetime | None = None
         self.logger = logger or logging.getLogger(__name__)
 
     def get_token(self) -> str:
@@ -109,6 +109,6 @@ class AuthService:
             return "eu"
 
     @property
-    def expires_at(self) -> Optional[datetime]:
+    def expires_at(self) -> datetime | None:
         """Public accessor for token expiration time."""
         return self._expires_at

--- a/python/heimdall_api_client/capacity_monitoring.py
+++ b/python/heimdall_api_client/capacity_monitoring.py
@@ -1,42 +1,82 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
 from uuid import UUID
+
 from heimdall_api_client.assets_api_client.client import AuthenticatedClient
 from heimdall_api_client.capacity_monitoring_api_client.api.line import (
-    capacity_monitoring_v1_lines_get_latest_heimdall_dlr as get_latest_dlr,
     capacity_monitoring_v1_lines_get_latest_heimdall_aar as get_latest_aar,
-    capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts as get_latest_dlr_forecasts,
+)
+from heimdall_api_client.capacity_monitoring_api_client.api.line import (
     capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts as get_latest_aar_forecasts,
 )
+from heimdall_api_client.capacity_monitoring_api_client.api.line import (
+    capacity_monitoring_v1_lines_get_latest_heimdall_dlr as get_latest_dlr,
+)
+from heimdall_api_client.capacity_monitoring_api_client.api.line import (
+    capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts as get_latest_dlr_forecasts,
+)
+
+if TYPE_CHECKING:
+    from heimdall_api_client.capacity_monitoring_api_client.models.capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_response_200 import (  # noqa: E501
+        CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200,
+    )
+    from heimdall_api_client.capacity_monitoring_api_client.models.capacity_monitoring_v1_facilities_get_latest_circuit_rating_response_200 import (  # noqa: E501
+        CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200,
+    )
+    from heimdall_api_client.capacity_monitoring_api_client.models.capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_response_200 import (  # noqa: E501
+        CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200,
+    )
+    from heimdall_api_client.capacity_monitoring_api_client.models.capacity_monitoring_v1_lines_get_latest_heimdall_aar_response_200 import (  # noqa: E501
+        CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200,
+    )
+    from heimdall_api_client.capacity_monitoring_api_client.models.capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_response_200 import (  # noqa: E501
+        CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200,
+    )
+    from heimdall_api_client.capacity_monitoring_api_client.models.capacity_monitoring_v1_lines_get_latest_heimdall_dlr_response_200 import (  # noqa: E501
+        CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200,
+    )
 
 
-def get_latest_heimdall_dlr(client: AuthenticatedClient, line_id: UUID, region: str):
+def get_latest_heimdall_dlr(
+    client: AuthenticatedClient, line_id: UUID, region: str
+) -> CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200:
     response = get_latest_dlr.sync_detailed(client=client, line_id=line_id, x_region=region)
     if response.status_code != 200:
         raise Exception(f"Error fetching latest Heimdall DLR: {response.status_code} {response.text}")
     return response.parsed
 
 
-def get_latest_heimdall_aar(client: AuthenticatedClient, line_id: UUID, region: str):
+def get_latest_heimdall_aar(
+    client: AuthenticatedClient, line_id: UUID, region: str
+) -> CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200:
     response = get_latest_aar.sync_detailed(client=client, line_id=line_id, x_region=region)
     if response.status_code != 200:
         raise Exception(f"Error fetching latest Heimdall AAR: {response.status_code} {response.text}")
     return response.parsed
 
 
-def get_latest_heimdall_dlr_forecasts(client: AuthenticatedClient, line_id: UUID, region: str):
+def get_latest_heimdall_dlr_forecasts(
+    client: AuthenticatedClient, line_id: UUID, region: str
+) -> CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200:
     response = get_latest_dlr_forecasts.sync_detailed(client=client, line_id=line_id, x_region=region)
     if response.status_code != 200:
         raise Exception(f"Error fetching latest Heimdall DLR forecasts: {response.status_code} {response.text}")
     return response.parsed
 
 
-def get_latest_heimdall_arr_forecasts(client: AuthenticatedClient, line_id: UUID, region: str):
+def get_latest_heimdall_arr_forecasts(
+    client: AuthenticatedClient, line_id: UUID, region: str
+) -> CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200:
     response = get_latest_aar_forecasts.sync_detailed(client=client, line_id=line_id, x_region=region)
     if response.status_code != 200:
         raise Exception(f"Error fetching latest Heimdall AAR forecasts: {response.status_code} {response.text}")
     return response.parsed
 
 
-def get_latest_circuit_ratring(client: AuthenticatedClient, facility_id: UUID, x_region: str):
+def get_latest_circuit_ratring(
+    client: AuthenticatedClient, facility_id: UUID, x_region: str
+) -> CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200:
     from heimdall_api_client.capacity_monitoring_api_client.api.facility import (
         capacity_monitoring_v1_facilities_get_latest_circuit_rating as get_latest_circuit_rating,
     )
@@ -47,7 +87,9 @@ def get_latest_circuit_ratring(client: AuthenticatedClient, facility_id: UUID, x
     return response.parsed
 
 
-def get_latest_circuit_rating_forecasts(client: AuthenticatedClient, facility_id: UUID, x_region: str):
+def get_latest_circuit_rating_forecasts(
+    client: AuthenticatedClient, facility_id: UUID, x_region: str
+) -> CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200:
     from heimdall_api_client.capacity_monitoring_api_client.api.facility import (
         capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts as get_latest_circuit_rating_forecasts,
     )

--- a/python/heimdall_api_client/client.py
+++ b/python/heimdall_api_client/client.py
@@ -1,17 +1,52 @@
-import logging
-from typing import List, Optional
-from uuid import UUID
+from __future__ import annotations
+
 import datetime
-from heimdall_api_client.grid_insights_api_client.models.unit_system import UnitSystem
-from heimdall_api_client.auth import AuthService
+import logging
+from typing import TYPE_CHECKING
+from uuid import UUID
+
 from heimdall_api_client.assets import get_assets
+from heimdall_api_client.assets_api_client.client import AuthenticatedClient
+from heimdall_api_client.auth import AuthService
 from heimdall_api_client.capacity_monitoring import (
     get_latest_heimdall_aar,
     get_latest_heimdall_arr_forecasts,
     get_latest_heimdall_dlr,
     get_latest_heimdall_dlr_forecasts,
 )
-from heimdall_api_client.assets_api_client.client import AuthenticatedClient
+from heimdall_api_client.grid_insights_api_client.models.unit_system import UnitSystem
+
+if TYPE_CHECKING:
+    from heimdall_api_client.assets_api_client.models.assets_v1_get_assets_response_200 import (
+        AssetsV1GetAssetsResponse200,
+    )
+    from heimdall_api_client.capacity_monitoring_api_client.models.capacity_monitoring_v1_facilities_get_latest_circuit_rating_forecasts_response_200 import (  # noqa: E501
+        CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200,
+    )
+    from heimdall_api_client.capacity_monitoring_api_client.models.capacity_monitoring_v1_facilities_get_latest_circuit_rating_response_200 import (  # noqa: E501
+        CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200,
+    )
+    from heimdall_api_client.capacity_monitoring_api_client.models.capacity_monitoring_v1_lines_get_latest_heimdall_aar_forecasts_response_200 import (  # noqa: E501
+        CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200,
+    )
+    from heimdall_api_client.capacity_monitoring_api_client.models.capacity_monitoring_v1_lines_get_latest_heimdall_aar_response_200 import (  # noqa: E501
+        CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200,
+    )
+    from heimdall_api_client.capacity_monitoring_api_client.models.capacity_monitoring_v1_lines_get_latest_heimdall_dlr_forecasts_response_200 import (  # noqa: E501
+        CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200,
+    )
+    from heimdall_api_client.capacity_monitoring_api_client.models.capacity_monitoring_v1_lines_get_latest_heimdall_dlr_response_200 import (  # noqa: E501
+        CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200,
+    )
+    from heimdall_api_client.grid_insights_api_client.models.grid_insights_v1_lines_get_latest_conductor_temperature_response_200 import (  # noqa: E501
+        GridInsightsV1LinesGetLatestConductorTemperatureResponse200,
+    )
+    from heimdall_api_client.grid_insights_api_client.models.grid_insights_v1_lines_get_latest_current_response_200 import (  # noqa: E501
+        GridInsightsV1LinesGetLatestCurrentResponse200,
+    )
+    from heimdall_api_client.grid_insights_api_client.models.grid_insights_v1_lines_get_latest_icing_response_200 import (  # noqa: E501
+        GridInsightsV1LinesGetLatestIcingResponse200,
+    )
 
 
 class HeimdallApiClient:
@@ -27,8 +62,8 @@ class HeimdallApiClient:
         auth_policy: str = "b2c_1a_clientcredentialsflow",
         tenant: str = "hpadb2cprod",
         auth_authority_domain: str = "hpadb2cprod.b2clogin.com",
-        auth_scope: Optional[List[str]] | None = None,
-        logger: Optional[logging.Logger] | None = None,
+        auth_scope: list[str] | None = None,
+        logger: logging.Logger | None = None,
         client_metadata: dict[str, str] | None = None,
     ):
         self.logger = logger or logging.getLogger(__name__)
@@ -59,13 +94,13 @@ class HeimdallApiClient:
     def _get_region(self) -> str:
         return self.auth_service.get_region_from_token()
 
-    def get_assets(self):
+    def get_assets(self) -> AssetsV1GetAssetsResponse200:
         """
         Returns the list of assets from the Assets API.
         """
         return get_assets(client=self._get_authenticated_client(), x_region=self._get_region())
 
-    def get_latest_heimdall_dlr(self, line_id: UUID):
+    def get_latest_heimdall_dlr(self, line_id: UUID) -> CapacityMonitoringV1LinesGetLatestHeimdallDlrResponse200:
         """
         Returns the latest Heimdall DLR (Dynamic Line rating) data.
         """
@@ -73,7 +108,7 @@ class HeimdallApiClient:
             client=self._get_authenticated_client(), line_id=line_id, region=self._get_region()
         )
 
-    def get_latest_heimdall_aar(self, line_id: UUID):
+    def get_latest_heimdall_aar(self, line_id: UUID) -> CapacityMonitoringV1LinesGetLatestHeimdallAarResponse200:
         """
         Returns the latest Heimdall AAR (Available Ampacity Rating) data.
         """
@@ -81,7 +116,9 @@ class HeimdallApiClient:
             client=self._get_authenticated_client(), line_id=line_id, region=self._get_region()
         )
 
-    def get_latest_heimdall_dlr_forecasts(self, line_id: UUID):
+    def get_latest_heimdall_dlr_forecasts(
+        self, line_id: UUID
+    ) -> CapacityMonitoringV1LinesGetLatestHeimdallDlrForecastsResponse200:
         """
         Returns the latest Heimdall DLR forecasts.
         """
@@ -89,7 +126,9 @@ class HeimdallApiClient:
             client=self._get_authenticated_client(), line_id=line_id, region=self._get_region()
         )
 
-    def get_latest_heimdall_aar_forecasts(self, line_id: UUID):
+    def get_latest_heimdall_aar_forecasts(
+        self, line_id: UUID
+    ) -> CapacityMonitoringV1LinesGetLatestHeimdallAarForecastsResponse200:
         """
         Returns the latest Heimdall AAR forecasts.
         """
@@ -97,7 +136,9 @@ class HeimdallApiClient:
             client=self._get_authenticated_client(), line_id=line_id, region=self._get_region()
         )
 
-    def get_latest_circuit_rating(self, facility_id: UUID):
+    def get_latest_circuit_rating(
+        self, facility_id: UUID
+    ) -> CapacityMonitoringV1FacilitiesGetLatestCircuitRatingResponse200:
         """
         Returns the latest circuit rating for a given facility.
         """
@@ -107,7 +148,9 @@ class HeimdallApiClient:
             client=self._get_authenticated_client(), facility_id=facility_id, x_region=self._get_region()
         )
 
-    def get_latest_circuit_rating_forecasts(self, facility_id: UUID):
+    def get_latest_circuit_rating_forecasts(
+        self, facility_id: UUID
+    ) -> CapacityMonitoringV1FacilitiesGetLatestCircuitRatingForecastsResponse200:
         """
         Returns the latest circuit rating forecasts for a given facility.
         """
@@ -117,7 +160,9 @@ class HeimdallApiClient:
             client=self._get_authenticated_client(), facility_id=facility_id, x_region=self._get_region()
         )
 
-    def get_latest_conductor_temperature(self, line_id: UUID):
+    def get_latest_conductor_temperature(
+        self, line_id: UUID
+    ) -> GridInsightsV1LinesGetLatestConductorTemperatureResponse200:
         """
         Returns the latest conductor temperature for a given line.
         """
@@ -127,7 +172,7 @@ class HeimdallApiClient:
             client=self._get_authenticated_client(), line_id=line_id, region=self._get_region()
         )
 
-    def get_latest_current(self, line_id: UUID):
+    def get_latest_current(self, line_id: UUID) -> GridInsightsV1LinesGetLatestCurrentResponse200:
         """
         Returns the latest current for a given line.
         """
@@ -140,7 +185,7 @@ class HeimdallApiClient:
         line_id: UUID,
         unit_system: UnitSystem | str | None = None,
         since: datetime.datetime | None = None,
-    ):
+    ) -> GridInsightsV1LinesGetLatestIcingResponse200:
         """
         Returns the latest icing measurements for a given line.
         """

--- a/python/heimdall_api_client/grid_insights.py
+++ b/python/heimdall_api_client/grid_insights.py
@@ -1,11 +1,28 @@
-from uuid import UUID
+from __future__ import annotations
+
 import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID
+
 from heimdall_api_client.assets_api_client.client import AuthenticatedClient
 from heimdall_api_client.grid_insights_api_client.models.unit_system import UnitSystem
 from heimdall_api_client.grid_insights_api_client.types import UNSET
 
+if TYPE_CHECKING:
+    from heimdall_api_client.grid_insights_api_client.models.grid_insights_v1_lines_get_latest_conductor_temperature_response_200 import (  # noqa: E501
+        GridInsightsV1LinesGetLatestConductorTemperatureResponse200,
+    )
+    from heimdall_api_client.grid_insights_api_client.models.grid_insights_v1_lines_get_latest_current_response_200 import (  # noqa: E501
+        GridInsightsV1LinesGetLatestCurrentResponse200,
+    )
+    from heimdall_api_client.grid_insights_api_client.models.grid_insights_v1_lines_get_latest_icing_response_200 import (  # noqa: E501
+        GridInsightsV1LinesGetLatestIcingResponse200,
+    )
 
-def get_latest_conductor_temperature(client: AuthenticatedClient, line_id: UUID, region: str):
+
+def get_latest_conductor_temperature(
+    client: AuthenticatedClient, line_id: UUID, region: str
+) -> GridInsightsV1LinesGetLatestConductorTemperatureResponse200:
     from heimdall_api_client.grid_insights_api_client.api.line import (
         grid_insights_v1_lines_get_latest_conductor_temperature as get_latest_conductor_temperature,
     )
@@ -16,7 +33,9 @@ def get_latest_conductor_temperature(client: AuthenticatedClient, line_id: UUID,
     return response.parsed
 
 
-def get_latest_current(client: AuthenticatedClient, line_id: UUID, region: str):
+def get_latest_current(
+    client: AuthenticatedClient, line_id: UUID, region: str
+) -> GridInsightsV1LinesGetLatestCurrentResponse200:
     from heimdall_api_client.grid_insights_api_client.api.line import (
         grid_insights_v1_lines_get_latest_current as get_latest_current,
     )
@@ -33,7 +52,7 @@ def get_latest_icing(
     region: str,
     unit_system: UnitSystem | str | None = None,
     since: datetime.datetime | None = None,
-):
+) -> GridInsightsV1LinesGetLatestIcingResponse200:
     from heimdall_api_client.grid_insights_api_client.api.line import (
         grid_insights_v1_lines_get_latest_icing as get_latest_icing,
     )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -26,7 +26,18 @@ exclude = ["examples"]
 [tool.ruff]
 line-length = 120
 target-version = "py311"
-# extend-exclude = ["heimdall_api_client/*_api_client"]
+extend-exclude = ["heimdall_api_client/*_api_client"]
+
+[tool.ruff.lint]
+select = [
+  "E",    # pycodestyle errors
+  "F",    # pyflakes
+  "I",    # isort (import sorting)
+  "UP",   # pyupgrade (modernize syntax for py311+)
+]
+
+[tool.ruff.format]
+# Inherits line-length and target-version from [tool.ruff]
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -36,4 +47,4 @@ build-backend = "poetry.core.masonry.api"
 markers = [
   "integration: marks tests as integration (use with '-m integration')"
 ]
-testpaths = ["tests/integration"]
+testpaths = ["tests"]

--- a/python/tests/integration/conftest.py
+++ b/python/tests/integration/conftest.py
@@ -1,5 +1,7 @@
 import os
+
 import pytest
+
 from heimdall_api_client import HeimdallApiClient
 
 


### PR DESCRIPTION
Improve Python SDK developer experience and CI reliability:
  - Add return type annotations to all public SDK methods using auto-generated response models, enabling IDE autocomplete for callers
  - Add py.typed marker (PEP 561) so type checkers recognize the package
  - Add ruff format --check step to CI (was documented but not enforced)
  - Configure ruff lint rules (E, F, I, UP) and exclude auto-generated *_api_client directories from linting
  - Bump setup-python from v4 to v5 for consistency across workflows
  - Fix .editorconfig charset from utf-8-bom to utf-8 (ruff strips BOM)
  - Fix typos and add .NET section to CONTRIBUTING.md
  - Fix E501 violations in example files