### PR TITLE
fix(python): replace deprecated datetime.utcnow and add auth unit tests

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -51,5 +51,8 @@ jobs:
       - name: Check formatting
         run: poetry run ruff format --check .
 
+      - name: Run unit tests
+        run: poetry run pytest tests/unit -v
+
       - name: Build package
         run: poetry build

--- a/python/heimdall_api_client/auth.py
+++ b/python/heimdall_api_client/auth.py
@@ -1,5 +1,5 @@
 import logging
-from datetime import datetime, timedelta
+from datetime import UTC, datetime, timedelta
 
 import jwt
 import requests
@@ -59,7 +59,7 @@ class AuthService:
 
             expires_in = token_json.get("expires_in")
             if expires_in:
-                self._expires_at = datetime.utcnow() + timedelta(seconds=int(expires_in))
+                self._expires_at = datetime.now(UTC) + timedelta(seconds=int(expires_in))
                 self.logger.debug(f"Token expires at {self._expires_at.isoformat()}")
 
             return self._access_token
@@ -81,7 +81,7 @@ class AuthService:
         """Returns True if the token is expired or missing."""
         if not self._expires_at:
             return True
-        return datetime.utcnow() >= self._expires_at
+        return datetime.now(UTC) >= self._expires_at
 
     def get_token_claims(self) -> dict:
         """Returns the decoded claims from the current access token."""

--- a/python/tests/unit/test_auth_service.py
+++ b/python/tests/unit/test_auth_service.py
@@ -2,7 +2,6 @@ from datetime import UTC, datetime, timedelta
 from unittest.mock import MagicMock, patch
 
 import jwt
-import pytest
 
 from heimdall_api_client.auth import AuthService
 

--- a/python/tests/unit/test_auth_service.py
+++ b/python/tests/unit/test_auth_service.py
@@ -1,0 +1,55 @@
+from datetime import UTC, datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import jwt
+import pytest
+
+from heimdall_api_client.auth import AuthService
+
+
+def _make_token(claims: dict) -> str:
+    return jwt.encode(claims, key="not-a-real-secret-just-for-tests", algorithm="HS256")
+
+
+def _mock_token_response(access_token: str, expires_in: int = 3600):
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "access_token": access_token,
+        "expires_in": expires_in,
+    }
+    return mock_response
+
+
+class TestGetValidToken:
+    @patch("heimdall_api_client.auth.requests.post")
+    def test_returns_cached_token_when_not_expired(self, mock_post):
+        token = _make_token({"sub": "test"})
+        mock_post.return_value = _mock_token_response(token)
+
+        auth = AuthService(client_id="test-id", client_secret="test-secret")
+        auth.get_valid_token()
+        auth.get_valid_token()
+
+        mock_post.assert_called_once()
+
+    @patch("heimdall_api_client.auth.requests.post")
+    def test_refetches_when_token_expired(self, mock_post):
+        token = _make_token({"sub": "test"})
+        mock_post.return_value = _mock_token_response(token)
+
+        auth = AuthService(client_id="test-id", client_secret="test-secret")
+        auth.get_valid_token()
+
+        auth._expires_at = datetime.now(UTC) - timedelta(seconds=1)
+        auth.get_valid_token()
+
+        assert mock_post.call_count == 2
+
+
+class TestGetRegionFromToken:
+    def test_defaults_to_eu_when_region_missing(self):
+        auth = AuthService(client_id="test-id", client_secret="test-secret")
+        auth._access_token = _make_token({"sub": "test"})
+
+        assert auth.get_region_from_token() == "eu"


### PR DESCRIPTION
  Replace datetime.utcnow() with timezone-aware datetime.now(UTC) to fix
  DeprecationWarning scheduled for removal in a future Python version.

  Add unit tests for AuthService covering token caching, expiration
  refresh, and region fallback. Add unit test step to CI workflow.