### PR TITLE
ci: add conventional commits PR title validation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
     labels:
       - "dependencies"
       - "dotnet"
+    commit-message:
+      prefix: "deps(nuget)"
     groups:
       nuget-dependencies:
         patterns:
@@ -30,6 +32,8 @@ updates:
       - "dependencies"
       - "python"
     versioning-strategy: auto
+    commit-message:
+      prefix: "deps(pip)"
     groups:
       pip-dependencies:
         patterns:

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,20 +1,21 @@
-name: Pull Request Validation
+name: "Conventional Commits PR title check"
 
 on:
   pull_request:
-    branches: [ main ]
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+permissions:
+  pull-requests: read
 
 jobs:
   validate-pr-title:
-    name: Validate PR Title
+    name: Validate
     runs-on: ubuntu-latest
-
     steps:
-      - name: Check PR title
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const title = context.payload.pull_request.title;
-            if (!title || title.trim().length < 5) {
-              core.setFailed("PR title is too short or missing.");
-            }
+      - uses: amannn/action-semantic-pull-request@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,13 +6,44 @@ This repository contains SDKs and example clients for accessing the [Heimdall Po
 
 ---
 
+## Conventional Commits
+
+This project follows the [Conventional Commits](https://www.conventionalcommits.org/) specification for commit messages and PR titles.
+
+**PR titles are validated by CI** — a PR with a non-conforming title will fail the status check.
+
+### Format
+
+```
+type(scope): description
+```
+
+**Types:** `feat`, `fix`, `docs`, `refactor`, `test`, `chore`, `ci`, `build`, `style`, `perf`
+
+**Scope** (optional): use when the change is clearly module-specific, e.g. `python`, `dotnet`.
+
+**Description:** imperative, lowercase, no trailing period. Include the Jira ticket if applicable.
+
+### Examples
+
+```
+feat: add new endpoint for circuit ratings
+feat(dotnet): POWER-4075 add proxy configuration for API client
+fix(python): handle missing auth token gracefully
+docs: update contributing guidelines
+ci: add conventional commits PR title validation
+```
+
+---
+
 ## Pull Requests
 
-- All pull requests must have a **clear title** (min. 5 characters).
+- PR titles **must** follow the [Conventional Commits](#conventional-commits) format.
 - Include a short description of what the PR does and why.
 - Pull requests targeting `main` must be reviewed by a **code owner**.
 
 > Heimdall Power's backend team (`@heimdallpower/backend`) is configured as the code owner. Reviews will be automatically requested when a PR is opened.
+
 ---
 
 ## Branching & Releases


### PR DESCRIPTION
  Replace the basic title-length check with amannn/action-semantic-pull-request
  and document the convention in CONTRIBUTING.md. Add conventional commit
  prefixes to Dependabot config.