### PR TITLE
feat: POWER-4880 - Extend assets with components

### DIFF
--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/Assets/FacilityComponentDto.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/Assets/FacilityComponentDto.cs
@@ -1,0 +1,3 @@
+namespace HeimdallPower.Api.Client.Assets;
+
+public record FacilityComponentDto(Guid Id, string Name);

--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/Assets/FacilityDto.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/Assets/FacilityDto.cs
@@ -23,4 +23,9 @@ public record FacilityDto
     /// Line associated with the facility, if available.
     /// </summary>
     public LineDto? Line { get; init; }
+
+    /// <summary>
+    /// List of components associated with the facility
+    /// </summary>
+    public required IReadOnlyList<FacilityComponentDto> Components { get; init; }
 }

--- a/dotnet/examples/Api.Client.Examples/Program.cs
+++ b/dotnet/examples/Api.Client.Examples/Program.cs
@@ -48,5 +48,7 @@ var facility = facilities.First(f => f.Line != null && f.Line.Name.Equals(line.N
 var circuitRating = await api.GetLatestCircuitRatingAsync(facility.Id);
 var circuitRatingForecast = await api.GetCircuitRatingForecastsAsync(facility.Id);
 
-var limitingComponent = circuitRating.CircuitRating.AtFacilityComponentId?.ToString() ?? "none";
+var limitingComponent = circuitRating.CircuitRating.AtFacilityComponentId.HasValue
+    ? facility.Components.FirstOrDefault(c => c.Id == circuitRating.CircuitRating.AtFacilityComponentId.Value)?.Name ?? "unknown"
+    : "none";
 Console.WriteLine($"- Circuit Rating: {circuitRating.CircuitRating.Value} {circuitRating.Unit} at {circuitRating.CircuitRating.Timestamp}, limiting component: {limitingComponent}, IsFallback={circuitRating.CircuitRating.IsFallback}");

--- a/python/heimdall_api_client/assets_api_client/api/assets/assets_v1_get_assets.py
+++ b/python/heimdall_api_client/assets_api_client/api/assets/assets_v1_get_assets.py
@@ -1,21 +1,19 @@
 from http import HTTPStatus
-from typing import Any, Optional, Union, cast
+from typing import Any, cast
 
 import httpx
 
-from ...client import AuthenticatedClient, Client
-from ...types import Response
 from ... import errors
-
+from ...client import AuthenticatedClient, Client
 from ...models.assets_v1_get_assets_response_200 import AssetsV1GetAssetsResponse200
 from ...models.assets_v1_get_assets_x_region import AssetsV1GetAssetsXRegion
 from ...models.problem_details import ProblemDetails
-from ...types import Unset
+from ...types import Response, Unset
 
 
 def _get_kwargs(
     *,
-    x_region: Union[Unset, AssetsV1GetAssetsXRegion] = AssetsV1GetAssetsXRegion.EU,
+    x_region: AssetsV1GetAssetsXRegion | Unset = AssetsV1GetAssetsXRegion.EU,
 ) -> dict[str, Any]:
     headers: dict[str, Any] = {}
     if not isinstance(x_region, Unset):
@@ -31,23 +29,27 @@ def _get_kwargs(
 
 
 def _parse_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Optional[Union[Any, AssetsV1GetAssetsResponse200, ProblemDetails]]:
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Any | AssetsV1GetAssetsResponse200 | ProblemDetails | None:
     if response.status_code == 200:
         response_200 = AssetsV1GetAssetsResponse200.from_dict(response.json())
 
         return response_200
+
     if response.status_code == 401:
         response_401 = cast(Any, None)
         return response_401
+
     if response.status_code == 403:
         response_403 = ProblemDetails.from_dict(response.json())
 
         return response_403
+
     if response.status_code == 500:
         response_500 = ProblemDetails.from_dict(response.json())
 
         return response_500
+
     if client.raise_on_unexpected_status:
         raise errors.UnexpectedStatus(response.status_code, response.content)
     else:
@@ -55,8 +57,8 @@ def _parse_response(
 
 
 def _build_response(
-    *, client: Union[AuthenticatedClient, Client], response: httpx.Response
-) -> Response[Union[Any, AssetsV1GetAssetsResponse200, ProblemDetails]]:
+    *, client: AuthenticatedClient | Client, response: httpx.Response
+) -> Response[Any | AssetsV1GetAssetsResponse200 | ProblemDetails]:
     return Response(
         status_code=HTTPStatus(response.status_code),
         content=response.content,
@@ -67,23 +69,23 @@ def _build_response(
 
 def sync_detailed(
     *,
-    client: Union[AuthenticatedClient, Client],
-    x_region: Union[Unset, AssetsV1GetAssetsXRegion] = AssetsV1GetAssetsXRegion.EU,
-) -> Response[Union[Any, AssetsV1GetAssetsResponse200, ProblemDetails]]:
+    client: AuthenticatedClient | Client,
+    x_region: AssetsV1GetAssetsXRegion | Unset = AssetsV1GetAssetsXRegion.EU,
+) -> Response[Any | AssetsV1GetAssetsResponse200 | ProblemDetails]:
     """Get assets
 
      This endpoint gets all assets you have access to, structured in the hierarchy described in the
     introduction.
 
     Args:
-        x_region (Union[Unset, AssetsV1GetAssetsXRegion]):  Default: AssetsV1GetAssetsXRegion.EU.
+        x_region (AssetsV1GetAssetsXRegion | Unset):  Default: AssetsV1GetAssetsXRegion.EU.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, AssetsV1GetAssetsResponse200, ProblemDetails]]
+        Response[Any | AssetsV1GetAssetsResponse200 | ProblemDetails]
     """
 
     kwargs = _get_kwargs(
@@ -99,23 +101,23 @@ def sync_detailed(
 
 def sync(
     *,
-    client: Union[AuthenticatedClient, Client],
-    x_region: Union[Unset, AssetsV1GetAssetsXRegion] = AssetsV1GetAssetsXRegion.EU,
-) -> Optional[Union[Any, AssetsV1GetAssetsResponse200, ProblemDetails]]:
+    client: AuthenticatedClient | Client,
+    x_region: AssetsV1GetAssetsXRegion | Unset = AssetsV1GetAssetsXRegion.EU,
+) -> Any | AssetsV1GetAssetsResponse200 | ProblemDetails | None:
     """Get assets
 
      This endpoint gets all assets you have access to, structured in the hierarchy described in the
     introduction.
 
     Args:
-        x_region (Union[Unset, AssetsV1GetAssetsXRegion]):  Default: AssetsV1GetAssetsXRegion.EU.
+        x_region (AssetsV1GetAssetsXRegion | Unset):  Default: AssetsV1GetAssetsXRegion.EU.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, AssetsV1GetAssetsResponse200, ProblemDetails]
+        Any | AssetsV1GetAssetsResponse200 | ProblemDetails
     """
 
     return sync_detailed(
@@ -126,23 +128,23 @@ def sync(
 
 async def asyncio_detailed(
     *,
-    client: Union[AuthenticatedClient, Client],
-    x_region: Union[Unset, AssetsV1GetAssetsXRegion] = AssetsV1GetAssetsXRegion.EU,
-) -> Response[Union[Any, AssetsV1GetAssetsResponse200, ProblemDetails]]:
+    client: AuthenticatedClient | Client,
+    x_region: AssetsV1GetAssetsXRegion | Unset = AssetsV1GetAssetsXRegion.EU,
+) -> Response[Any | AssetsV1GetAssetsResponse200 | ProblemDetails]:
     """Get assets
 
      This endpoint gets all assets you have access to, structured in the hierarchy described in the
     introduction.
 
     Args:
-        x_region (Union[Unset, AssetsV1GetAssetsXRegion]):  Default: AssetsV1GetAssetsXRegion.EU.
+        x_region (AssetsV1GetAssetsXRegion | Unset):  Default: AssetsV1GetAssetsXRegion.EU.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Response[Union[Any, AssetsV1GetAssetsResponse200, ProblemDetails]]
+        Response[Any | AssetsV1GetAssetsResponse200 | ProblemDetails]
     """
 
     kwargs = _get_kwargs(
@@ -156,23 +158,23 @@ async def asyncio_detailed(
 
 async def asyncio(
     *,
-    client: Union[AuthenticatedClient, Client],
-    x_region: Union[Unset, AssetsV1GetAssetsXRegion] = AssetsV1GetAssetsXRegion.EU,
-) -> Optional[Union[Any, AssetsV1GetAssetsResponse200, ProblemDetails]]:
+    client: AuthenticatedClient | Client,
+    x_region: AssetsV1GetAssetsXRegion | Unset = AssetsV1GetAssetsXRegion.EU,
+) -> Any | AssetsV1GetAssetsResponse200 | ProblemDetails | None:
     """Get assets
 
      This endpoint gets all assets you have access to, structured in the hierarchy described in the
     introduction.
 
     Args:
-        x_region (Union[Unset, AssetsV1GetAssetsXRegion]):  Default: AssetsV1GetAssetsXRegion.EU.
+        x_region (AssetsV1GetAssetsXRegion | Unset):  Default: AssetsV1GetAssetsXRegion.EU.
 
     Raises:
         errors.UnexpectedStatus: If the server returns an undocumented status code and Client.raise_on_unexpected_status is True.
         httpx.TimeoutException: If the request takes longer than Client.timeout.
 
     Returns:
-        Union[Any, AssetsV1GetAssetsResponse200, ProblemDetails]
+        Any | AssetsV1GetAssetsResponse200 | ProblemDetails
     """
 
     return (

--- a/python/heimdall_api_client/assets_api_client/client.py
+++ b/python/heimdall_api_client/assets_api_client/client.py
@@ -1,8 +1,8 @@
 import ssl
-from typing import Any, Union, Optional
+from typing import Any
 
-from attrs import define, field, evolve
 import httpx
+from attrs import define, evolve, field
 
 
 @define
@@ -38,12 +38,12 @@ class Client:
     _base_url: str = field(alias="base_url")
     _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
     _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
-    _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
-    _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(default=True, kw_only=True, alias="verify_ssl")
     _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
     _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
-    _client: Optional[httpx.Client] = field(default=None, init=False)
-    _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
 
     def with_headers(self, headers: dict[str, str]) -> "Client":
         """Get a new client matching this one with additional headers"""
@@ -62,7 +62,7 @@ class Client:
         return evolve(self, cookies={**self._cookies, **cookies})
 
     def with_timeout(self, timeout: httpx.Timeout) -> "Client":
-        """Get a new client matching this one with a new timeout (in seconds)"""
+        """Get a new client matching this one with a new timeout configuration"""
         if self._client is not None:
             self._client.timeout = timeout
         if self._async_client is not None:
@@ -101,7 +101,7 @@ class Client:
         self.get_httpx_client().__exit__(*args, **kwargs)
 
     def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "Client":
-        """Manually the underlying httpx.AsyncClient
+        """Manually set the underlying httpx.AsyncClient
 
         **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
         """
@@ -168,12 +168,12 @@ class AuthenticatedClient:
     _base_url: str = field(alias="base_url")
     _cookies: dict[str, str] = field(factory=dict, kw_only=True, alias="cookies")
     _headers: dict[str, str] = field(factory=dict, kw_only=True, alias="headers")
-    _timeout: Optional[httpx.Timeout] = field(default=None, kw_only=True, alias="timeout")
-    _verify_ssl: Union[str, bool, ssl.SSLContext] = field(default=True, kw_only=True, alias="verify_ssl")
+    _timeout: httpx.Timeout | None = field(default=None, kw_only=True, alias="timeout")
+    _verify_ssl: str | bool | ssl.SSLContext = field(default=True, kw_only=True, alias="verify_ssl")
     _follow_redirects: bool = field(default=False, kw_only=True, alias="follow_redirects")
     _httpx_args: dict[str, Any] = field(factory=dict, kw_only=True, alias="httpx_args")
-    _client: Optional[httpx.Client] = field(default=None, init=False)
-    _async_client: Optional[httpx.AsyncClient] = field(default=None, init=False)
+    _client: httpx.Client | None = field(default=None, init=False)
+    _async_client: httpx.AsyncClient | None = field(default=None, init=False)
 
     token: str
     prefix: str = "Bearer"
@@ -196,7 +196,7 @@ class AuthenticatedClient:
         return evolve(self, cookies={**self._cookies, **cookies})
 
     def with_timeout(self, timeout: httpx.Timeout) -> "AuthenticatedClient":
-        """Get a new client matching this one with a new timeout (in seconds)"""
+        """Get a new client matching this one with a new timeout configuration"""
         if self._client is not None:
             self._client.timeout = timeout
         if self._async_client is not None:
@@ -236,7 +236,7 @@ class AuthenticatedClient:
         self.get_httpx_client().__exit__(*args, **kwargs)
 
     def set_async_httpx_client(self, async_client: httpx.AsyncClient) -> "AuthenticatedClient":
-        """Manually the underlying httpx.AsyncClient
+        """Manually set the underlying httpx.AsyncClient
 
         **NOTE**: This will override any other settings on the client, including cookies, headers, and timeout.
         """

--- a/python/heimdall_api_client/assets_api_client/models/__init__.py
+++ b/python/heimdall_api_client/assets_api_client/models/__init__.py
@@ -5,6 +5,7 @@ from .assets import Assets
 from .assets_v1_get_assets_response_200 import AssetsV1GetAssetsResponse200
 from .assets_v1_get_assets_x_region import AssetsV1GetAssetsXRegion
 from .facility import Facility
+from .facility_component import FacilityComponent
 from .grid_owner import GridOwner
 from .line_type_0 import LineType0
 from .problem_details import ProblemDetails
@@ -17,6 +18,7 @@ __all__ = (
     "AssetsV1GetAssetsResponse200",
     "AssetsV1GetAssetsXRegion",
     "Facility",
+    "FacilityComponent",
     "GridOwner",
     "LineType0",
     "ProblemDetails",

--- a/python/heimdall_api_client/assets_api_client/models/api_response.py
+++ b/python/heimdall_api_client/assets_api_client/models/api_response.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from typing import Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
-
 
 T = TypeVar("T", bound="ApiResponse")
 

--- a/python/heimdall_api_client/assets_api_client/models/assets.py
+++ b/python/heimdall_api_client/assets_api_client/models/assets.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
-from typing import Any, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
@@ -15,10 +17,10 @@ T = TypeVar("T", bound="Assets")
 class Assets:
     """
     Attributes:
-        grid_owners (list['GridOwner']): List of grid owners the API consumer has access to.
+        grid_owners (list[GridOwner]): List of grid owners the API consumer has access to.
     """
 
-    grid_owners: list["GridOwner"]
+    grid_owners: list[GridOwner]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/python/heimdall_api_client/assets_api_client/models/facility.py
+++ b/python/heimdall_api_client/assets_api_client/models/facility.py
@@ -1,16 +1,16 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
-from typing import Any, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-from typing import cast
-from typing import Union
-from uuid import UUID
-
 if TYPE_CHECKING:
+    from ..models.facility_component import FacilityComponent
     from ..models.line_type_0 import LineType0
 
 
@@ -23,12 +23,14 @@ class Facility:
     Attributes:
         id (UUID): Unique identifier of the facility. Example: 00000000-0000-0000-0000-000000000000.
         name (str): Name of the facility. Example: Facility A.
-        line (Union['LineType0', None, Unset]):
+        components (list[FacilityComponent]): List of facility components belonging to the facility.
+        line (LineType0 | None | Unset):
     """
 
     id: UUID
     name: str
-    line: Union["LineType0", None, Unset] = UNSET
+    components: list[FacilityComponent]
+    line: LineType0 | None | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -38,7 +40,12 @@ class Facility:
 
         name = self.name
 
-        line: Union[None, Unset, dict[str, Any]]
+        components = []
+        for components_item_data in self.components:
+            components_item = components_item_data.to_dict()
+            components.append(components_item)
+
+        line: dict[str, Any] | None | Unset
         if isinstance(self.line, Unset):
             line = UNSET
         elif isinstance(self.line, LineType0):
@@ -52,6 +59,7 @@ class Facility:
             {
                 "id": id,
                 "name": name,
+                "components": components,
             }
         )
         if line is not UNSET:
@@ -61,6 +69,7 @@ class Facility:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
+        from ..models.facility_component import FacilityComponent
         from ..models.line_type_0 import LineType0
 
         d = dict(src_dict)
@@ -68,7 +77,14 @@ class Facility:
 
         name = d.pop("name")
 
-        def _parse_line(data: object) -> Union["LineType0", None, Unset]:
+        components = []
+        _components = d.pop("components")
+        for components_item_data in _components:
+            components_item = FacilityComponent.from_dict(components_item_data)
+
+            components.append(components_item)
+
+        def _parse_line(data: object) -> LineType0 | None | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
@@ -79,15 +95,16 @@ class Facility:
                 componentsschemas_line_type_0 = LineType0.from_dict(data)
 
                 return componentsschemas_line_type_0
-            except:  # noqa: E722
+            except (TypeError, ValueError, AttributeError, KeyError):
                 pass
-            return cast(Union["LineType0", None, Unset], data)
+            return cast(LineType0 | None | Unset, data)
 
         line = _parse_line(d.pop("line", UNSET))
 
         facility = cls(
             id=id,
             name=name,
+            components=components,
             line=line,
         )
 

--- a/python/heimdall_api_client/assets_api_client/models/facility_component.py
+++ b/python/heimdall_api_client/assets_api_client/models/facility_component.py
@@ -1,36 +1,38 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar
+from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
-if TYPE_CHECKING:
-    from ..models.assets import Assets
-
-
-T = TypeVar("T", bound="AssetsV1GetAssetsResponse200")
+T = TypeVar("T", bound="FacilityComponent")
 
 
 @_attrs_define
-class AssetsV1GetAssetsResponse200:
+class FacilityComponent:
     """
     Attributes:
-        data (Assets):
+        id (UUID): Unique identifier of the facility component. Example: 00000000-0000-0000-0000-000000000000.
+        name (str): Name of the facility component. Example: Circuit Breaker A.
     """
 
-    data: Assets
+    id: UUID
+    name: str
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
-        data = self.data.to_dict()
+        id = str(self.id)
+
+        name = self.name
 
         field_dict: dict[str, Any] = {}
         field_dict.update(self.additional_properties)
         field_dict.update(
             {
-                "data": data,
+                "id": id,
+                "name": name,
             }
         )
 
@@ -38,17 +40,18 @@ class AssetsV1GetAssetsResponse200:
 
     @classmethod
     def from_dict(cls: type[T], src_dict: Mapping[str, Any]) -> T:
-        from ..models.assets import Assets
-
         d = dict(src_dict)
-        data = Assets.from_dict(d.pop("data"))
+        id = UUID(d.pop("id"))
 
-        assets_v1_get_assets_response_200 = cls(
-            data=data,
+        name = d.pop("name")
+
+        facility_component = cls(
+            id=id,
+            name=name,
         )
 
-        assets_v1_get_assets_response_200.additional_properties = d
-        return assets_v1_get_assets_response_200
+        facility_component.additional_properties = d
+        return facility_component
 
     @property
     def additional_keys(self) -> list[str]:

--- a/python/heimdall_api_client/assets_api_client/models/grid_owner.py
+++ b/python/heimdall_api_client/assets_api_client/models/grid_owner.py
@@ -1,9 +1,10 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
-from typing import Any, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
-
 
 if TYPE_CHECKING:
     from ..models.facility import Facility
@@ -17,11 +18,11 @@ class GridOwner:
     """
     Attributes:
         name (str): Name of the grid owner. Example: Grid owner A.
-        facilities (list['Facility']): List of facilities associated with the grid owner.
+        facilities (list[Facility]): List of facilities associated with the grid owner.
     """
 
     name: str
-    facilities: list["Facility"]
+    facilities: list[Facility]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/python/heimdall_api_client/assets_api_client/models/line_type_0.py
+++ b/python/heimdall_api_client/assets_api_client/models/line_type_0.py
@@ -1,11 +1,11 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
-from typing import Any, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeVar
+from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
-
-
-from uuid import UUID
 
 if TYPE_CHECKING:
     from ..models.span import Span
@@ -22,13 +22,13 @@ class LineType0:
         name (str): Name of the line. Example: Line A.
         available_forecast_hours (int): The available forecast length in hours, used as a query parameter for DLR
             forecasts. The maximum is 240 hours. Example: 72.
-        spans (list['Span']): List of spans belonging to the line.
+        spans (list[Span]): List of spans belonging to the line.
     """
 
     id: UUID
     name: str
     available_forecast_hours: int
-    spans: list["Span"]
+    spans: list[Span]
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/python/heimdall_api_client/assets_api_client/models/problem_details.py
+++ b/python/heimdall_api_client/assets_api_client/models/problem_details.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
 from typing import Any, TypeVar
 
@@ -6,9 +8,6 @@ from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
 
-from typing import Union
-
-
 T = TypeVar("T", bound="ProblemDetails")
 
 
@@ -16,18 +15,18 @@ T = TypeVar("T", bound="ProblemDetails")
 class ProblemDetails:
     """
     Attributes:
-        type_ (Union[Unset, str]):
-        title (Union[Unset, str]):
-        status (Union[Unset, int]):
-        detail (Union[Unset, str]):
-        instance (Union[Unset, str]):
+        type_ (str | Unset):
+        title (str | Unset):
+        status (int | Unset):
+        detail (str | Unset):
+        instance (str | Unset):
     """
 
-    type_: Union[Unset, str] = UNSET
-    title: Union[Unset, str] = UNSET
-    status: Union[Unset, int] = UNSET
-    detail: Union[Unset, str] = UNSET
-    instance: Union[Unset, str] = UNSET
+    type_: str | Unset = UNSET
+    title: str | Unset = UNSET
+    status: int | Unset = UNSET
+    detail: str | Unset = UNSET
+    instance: str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:

--- a/python/heimdall_api_client/assets_api_client/models/span.py
+++ b/python/heimdall_api_client/assets_api_client/models/span.py
@@ -1,14 +1,13 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
-from typing import Any, TypeVar, TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, TypeVar, cast
+from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
-
-from typing import cast
-from typing import Union
-from uuid import UUID
 
 if TYPE_CHECKING:
     from ..models.span_phase import SpanPhase
@@ -22,15 +21,15 @@ class Span:
     """
     Attributes:
         id (UUID): Unique identifier of the span. Example: 00000000-0000-0000-0000-000000000000.
-        span_phases (list['SpanPhase']): List of span phases associated with the span.
-        mast_name_a (Union[None, Unset, str]): Name of the first mast in the span. Example: Mast A.
-        mast_name_b (Union[None, Unset, str]): Name of the second mast in the span. Example: Mast B.
+        span_phases (list[SpanPhase]): List of span phases associated with the span.
+        mast_name_a (None | str | Unset): Name of the first mast in the span. Example: Mast A.
+        mast_name_b (None | str | Unset): Name of the second mast in the span. Example: Mast B.
     """
 
     id: UUID
-    span_phases: list["SpanPhase"]
-    mast_name_a: Union[None, Unset, str] = UNSET
-    mast_name_b: Union[None, Unset, str] = UNSET
+    span_phases: list[SpanPhase]
+    mast_name_a: None | str | Unset = UNSET
+    mast_name_b: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
@@ -41,13 +40,13 @@ class Span:
             span_phases_item = span_phases_item_data.to_dict()
             span_phases.append(span_phases_item)
 
-        mast_name_a: Union[None, Unset, str]
+        mast_name_a: None | str | Unset
         if isinstance(self.mast_name_a, Unset):
             mast_name_a = UNSET
         else:
             mast_name_a = self.mast_name_a
 
-        mast_name_b: Union[None, Unset, str]
+        mast_name_b: None | str | Unset
         if isinstance(self.mast_name_b, Unset):
             mast_name_b = UNSET
         else:
@@ -82,21 +81,21 @@ class Span:
 
             span_phases.append(span_phases_item)
 
-        def _parse_mast_name_a(data: object) -> Union[None, Unset, str]:
+        def _parse_mast_name_a(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(Union[None, Unset, str], data)
+            return cast(None | str | Unset, data)
 
         mast_name_a = _parse_mast_name_a(d.pop("mast_name_a", UNSET))
 
-        def _parse_mast_name_b(data: object) -> Union[None, Unset, str]:
+        def _parse_mast_name_b(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(Union[None, Unset, str], data)
+            return cast(None | str | Unset, data)
 
         mast_name_b = _parse_mast_name_b(d.pop("mast_name_b", UNSET))
 

--- a/python/heimdall_api_client/assets_api_client/models/span_phase.py
+++ b/python/heimdall_api_client/assets_api_client/models/span_phase.py
@@ -1,14 +1,13 @@
+from __future__ import annotations
+
 from collections.abc import Mapping
-from typing import Any, TypeVar
+from typing import Any, TypeVar, cast
+from uuid import UUID
 
 from attrs import define as _attrs_define
 from attrs import field as _attrs_field
 
 from ..types import UNSET, Unset
-
-from typing import cast, Union
-from uuid import UUID
-
 
 T = TypeVar("T", bound="SpanPhase")
 
@@ -18,17 +17,17 @@ class SpanPhase:
     """
     Attributes:
         id (UUID): Unique identifier of the span phase. Example: 00000000-0000-0000-0000-000000000000.
-        name (Union[None, Unset, str]): Name of the span phase, defined by the grid owner. Example: Phase A.
+        name (None | str | Unset): Name of the span phase, defined by the grid owner. Example: Phase A.
     """
 
     id: UUID
-    name: Union[None, Unset, str] = UNSET
+    name: None | str | Unset = UNSET
     additional_properties: dict[str, Any] = _attrs_field(init=False, factory=dict)
 
     def to_dict(self) -> dict[str, Any]:
         id = str(self.id)
 
-        name: Union[None, Unset, str]
+        name: None | str | Unset
         if isinstance(self.name, Unset):
             name = UNSET
         else:
@@ -51,12 +50,12 @@ class SpanPhase:
         d = dict(src_dict)
         id = UUID(d.pop("id"))
 
-        def _parse_name(data: object) -> Union[None, Unset, str]:
+        def _parse_name(data: object) -> None | str | Unset:
             if data is None:
                 return data
             if isinstance(data, Unset):
                 return data
-            return cast(Union[None, Unset, str], data)
+            return cast(None | str | Unset, data)
 
         name = _parse_name(d.pop("name", UNSET))
 

--- a/python/heimdall_api_client/assets_api_client/types.py
+++ b/python/heimdall_api_client/assets_api_client/types.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Mapping, MutableMapping
 from http import HTTPStatus
-from typing import BinaryIO, Generic, Optional, TypeVar, Literal, Union, IO
+from typing import IO, BinaryIO, Generic, Literal, TypeVar
 
 from attrs import define
 
@@ -15,13 +15,13 @@ class Unset:
 UNSET: Unset = Unset()
 
 # The types that `httpx.Client(files=)` can accept, copied from that library.
-FileContent = Union[IO[bytes], bytes, str]
-FileTypes = Union[
+FileContent = IO[bytes] | bytes | str
+FileTypes = (
     # (filename, file (or bytes), content_type)
-    tuple[Optional[str], FileContent, Optional[str]],
+    tuple[str | None, FileContent, str | None]
     # (filename, file (or bytes), content_type, headers)
-    tuple[Optional[str], FileContent, Optional[str], Mapping[str, str]],
-]
+    | tuple[str | None, FileContent, str | None, Mapping[str, str]]
+)
 RequestFiles = list[tuple[str, FileTypes]]
 
 
@@ -30,8 +30,8 @@ class File:
     """Contains information for file uploads"""
 
     payload: BinaryIO
-    file_name: Optional[str] = None
-    mime_type: Optional[str] = None
+    file_name: str | None = None
+    mime_type: str | None = None
 
     def to_tuple(self) -> FileTypes:
         """Return a tuple representation that httpx will accept for multipart/form-data"""
@@ -48,7 +48,7 @@ class Response(Generic[T]):
     status_code: HTTPStatus
     content: bytes
     headers: MutableMapping[str, str]
-    parsed: Optional[T]
+    parsed: T | None
 
 
 __all__ = ["UNSET", "File", "FileTypes", "RequestFiles", "Response", "Unset"]

--- a/python/scripts/generate-module-client.ps1
+++ b/python/scripts/generate-module-client.ps1
@@ -24,13 +24,26 @@ $generatedFolder = "${Module}_client"
 $targetPath = "../heimdall_api_client"
 
 # Check if openapi-python-client is installed
-python -m openapi_python_client --version 2>$null
-if ($LASTEXITCODE -ne 0) {
-    Write-Host "Installing 'openapi-python-client'..."
-    python -m pip install openapi-python-client
+$requiredVersion = "0.28.3"  # Pin the version here
+
+# Ensure correct version of openapi-python-client is installed
+$installedVersion = python -m openapi_python_client --version 2>$null
+if ($LASTEXITCODE -ne 0 -or $installedVersion -notmatch [regex]::Escape($requiredVersion)) {
+    Write-Host "Installing 'openapi-python-client' version $requiredVersion..."
+    python -m pip install "openapi-python-client==$requiredVersion" --quiet
+} else {
+    Write-Host "'openapi-python-client' $requiredVersion is already installed."
 }
-else {
-    Write-Host "'openapi-python-client' is already installed."
+
+# Warn if a newer version is available on PyPI
+try {
+    $pypiInfo = Invoke-RestMethod -Uri "https://pypi.org/pypi/openapi-python-client/json" -ErrorAction Stop
+    $latestVersion = $pypiInfo.info.version
+    if ($latestVersion -ne $requiredVersion) {
+        Write-Host "WARNING: A newer version of 'openapi-python-client' is available ($latestVersion). Currently pinned to $requiredVersion. Edit in 'generate-module-client.ps1'" -ForegroundColor Yellow
+    }
+} catch {
+    Write-Host "Could not check PyPI for latest 'openapi-python-client' version." -ForegroundColor DarkYellow
 }
 
 # Check if ruff is installed for linting


### PR DESCRIPTION
This pull request introduces support for facility components in both the .NET and Python API clients.
Facilities will now include a list of components when fetching assets. 
This can be used to map component ids to component names.
