### PR TITLE
feat: POWER-4980 - Add conductor temperatures and currents response models

### DIFF
--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/GridInsights/Lines/ConductorTemperaturesResponse.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/GridInsights/Lines/ConductorTemperaturesResponse.cs
@@ -1,0 +1,23 @@
+using HeimdallPower.Api.Client.GridInsights.Lines.Dtos;
+
+namespace HeimdallPower.Api.Client.GridInsights.Lines;
+
+public record ConductorTemperaturesResponse
+{
+    /// <summary>
+    /// The kind of data this response contains.
+    /// </summary>
+    /// <example>Conductor temperature</example>
+    public required string Metric { get; init; }
+
+    /// <summary>
+    /// The unit of the values in the response.
+    /// </summary>
+    /// <example>C</example>
+    public required string Unit { get; init; }
+
+    /// <summary>
+    /// List of conductor temperature measurements within the requested time range. May be empty if no data exists for the period.
+    /// </summary>
+    public required IReadOnlyCollection<ConductorTemperatureDto> ConductorTemperatures { get; init; }
+}

--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/GridInsights/Lines/CurrentsResponse.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/GridInsights/Lines/CurrentsResponse.cs
@@ -1,0 +1,23 @@
+using HeimdallPower.Api.Client.GridInsights.Lines.Dtos;
+
+namespace HeimdallPower.Api.Client.GridInsights.Lines;
+
+public record CurrentsResponse
+{
+    /// <summary>
+    /// The kind of data this response contains.
+    /// </summary>
+    /// <example>Current</example>
+    public required string Metric { get; init; }
+
+    /// <summary>
+    /// The unit of the values in the response.
+    /// </summary>
+    /// <example>Ampere</example>
+    public required string Unit { get; init; }
+
+    /// <summary>
+    /// List of current measurements within the requested time range. May be empty if no data exists for the period.
+    /// </summary>
+    public required IReadOnlyCollection<CurrentDto> Currents { get; init; }
+}

--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiClient.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallApiClient.cs
@@ -155,6 +155,39 @@ public class HeimdallApiClient : IHeimdallApiClient
     }
 
     /// <summary>
+    /// Get currents for the line within a time range.
+    /// Current is defined as the maximum current, in amperes, measured on the line at a given timestamp.
+    /// The current is aggregated across the entire line using a 5-minute sliding window, where the maximum value is calculated for each window.
+    /// The period between from and to must not exceed 30 days.
+    /// </summary>
+    /// <param name="lineId">Id of the line.</param>
+    /// <param name="from">Start of the time range (inclusive).</param>
+    /// <param name="to">End of the time range (inclusive).</param>
+    public async Task<CurrentsResponse> GetCurrentsAsync(Guid lineId, DateTimeOffset from, DateTimeOffset to)
+    {
+        var url = UrlBuilder.BuildCurrentsUrl(lineId, from, to);
+        var response = await _heimdallApiClient.GetAsync<ApiResponse<CurrentsResponse>>(url);
+        return response.Data;
+    }
+
+    /// <summary>
+    /// Get conductor temperatures for the line within a time range.
+    /// Conductor temperature is defined as the maximum and minimum temperature measured on the line at a given timestamp.
+    /// The conductor temperature is aggregated across the entire line using a 5-minute sliding window, where the maximum and minimum values are calculated for each window.
+    /// The period between from and to must not exceed 30 days.
+    /// </summary>
+    /// <param name="lineId">Id of the line.</param>
+    /// <param name="from">Start of the time range (inclusive).</param>
+    /// <param name="to">End of the time range (inclusive).</param>
+    /// <param name="unitSystem">The unit system for response values. "metric" gives values in Celsius (C), while "imperial" gives values in Fahrenheit (F). Defaults to metric if not specified.</param>
+    public async Task<ConductorTemperaturesResponse> GetConductorTemperaturesAsync(Guid lineId, DateTimeOffset from, DateTimeOffset to, string unitSystem = "metric")
+    {
+        var url = UrlBuilder.BuildConductorTemperaturesUrl(lineId, from, to, unitSystem);
+        var response = await _heimdallApiClient.GetAsync<ApiResponse<ConductorTemperaturesResponse>>(url);
+        return response.Data;
+    }
+
+    /// <summary>
     /// Get the most recent Heimdall Dynamic Line Rating (DLR) for the line.
     /// Heimdall DLR is calculated according to our own proprietary method, based on the CIGRE TB-601 standard for thermal calculation for OHLs.
     /// This method also takes the conductor temperature and current into account and uses these to adjust the weather parameters during calculations.
@@ -164,7 +197,7 @@ public class HeimdallApiClient : IHeimdallApiClient
     /// <param name="quantity">The quantity to return. Defaults to current (amperes). Use ApparentPower for MVA.</param>
     public async Task<LatestHeimdallDlrResponse> GetLatestHeimdallDlrAsync(Guid lineId, Quantity quantity = Quantity.Current)
     {
-        var url = UrlBuilder.BuildHeimdallDlrUrl(lineId, quantity);
+        var url = UrlBuilder.BuildLatestHeimdallDlrUrl(lineId, quantity);
         var response = await _heimdallApiClient.GetAsync<ApiResponse<LatestHeimdallDlrResponse>>(url);
 
         return response.Data;
@@ -180,7 +213,7 @@ public class HeimdallApiClient : IHeimdallApiClient
     /// <param name="quantity">The quantity to return. Defaults to current (amperes). Use ApparentPower for MVA.</param>
     public async Task<LatestHeimdallAarResponse> GetLatestHeimdallAarAsync(Guid lineId, Quantity quantity = Quantity.Current)
     {
-        var url = UrlBuilder.BuildHeimdallAarUrl(lineId, quantity);
+        var url = UrlBuilder.BuildLatestHeimdallAarUrl(lineId, quantity);
         var response = await _heimdallApiClient.GetAsync<ApiResponse<LatestHeimdallAarResponse>>(url);
 
         return response.Data;
@@ -272,7 +305,7 @@ public class HeimdallApiClient : IHeimdallApiClient
     /// <param name="quantity">The quantity to return. Defaults to current (amperes). Use ApparentPower for MVA.</param>
     public async Task<LatestCircuitRatingResponse> GetLatestCircuitRatingAsync(Guid facilityId, Quantity quantity = Quantity.Current)
     {
-        var url = UrlBuilder.BuildCircuitRatingUrl(facilityId, quantity);
+        var url = UrlBuilder.BuildLatestCircuitRatingUrl(facilityId, quantity);
         var response = await _heimdallApiClient.GetAsync<ApiResponse<LatestCircuitRatingResponse>>(url);
 
         return response.Data;

--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/IHeimdallApiClient.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/IHeimdallApiClient.cs
@@ -80,6 +80,29 @@ public interface IHeimdallApiClient
     Task<ApparentPowersResponse> GetApparentPowersAsync(Guid lineId, DateTimeOffset from, DateTimeOffset to);
 
     /// <summary>
+    /// Get currents for the line within a time range.
+    /// Current is defined as the maximum current, in amperes, measured on the line at a given timestamp.
+    /// The current is aggregated across the entire line using a 5-minute sliding window, where the maximum value is calculated for each window.
+    /// The period between from and to must not exceed 30 days.
+    /// </summary>
+    /// <param name="lineId">Id of the line.</param>
+    /// <param name="from">Start of the time range (inclusive).</param>
+    /// <param name="to">End of the time range (inclusive).</param>
+    Task<CurrentsResponse> GetCurrentsAsync(Guid lineId, DateTimeOffset from, DateTimeOffset to);
+
+    /// <summary>
+    /// Get conductor temperatures for the line within a time range.
+    /// Conductor temperature is defined as the maximum and minimum temperature measured on the line at a given timestamp.
+    /// The conductor temperature is aggregated across the entire line using a 5-minute sliding window, where the maximum and minimum values are calculated for each window.
+    /// The period between from and to must not exceed 30 days.
+    /// </summary>
+    /// <param name="lineId">Id of the line.</param>
+    /// <param name="from">Start of the time range (inclusive).</param>
+    /// <param name="to">End of the time range (inclusive).</param>
+    /// <param name="unitSystem">The unit system for response values. "metric" gives values in Celsius (C), while "imperial" gives values in Fahrenheit (F). Defaults to metric if not specified.</param>
+    Task<ConductorTemperaturesResponse> GetConductorTemperaturesAsync(Guid lineId, DateTimeOffset from, DateTimeOffset to, string unitSystem = "metric");
+
+    /// <summary>
     /// Get the most recent Heimdall Dynamic Line Rating (DLR) for the line.
     /// </summary>
     /// <param name="lineId">Id of the line for which to retrieve the latest Heimdall DLR.</param>

--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/UrlBuilder.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/UrlBuilder.cs
@@ -22,7 +22,9 @@ internal static class UrlBuilder
     private const string CircuitRatingForecasts = "circuit_ratings/forecasts";
     private const string CircuitRatingLatest = "circuit_ratings/latest";
     private const string ConductorTemperatures = "conductor_temperatures/latest";
+    private const string ConductorTemperaturesHistorical = "conductor_temperatures";
     private const string Currents = "currents/latest";
+    private const string CurrentsHistorical = "currents";
     private const string HeimdallDlrs = "heimdall_dlrs";
     private const string HeimdallDlr = "heimdall_dlrs/latest";
     private const string HeimdallAars = "heimdall_aars";
@@ -46,11 +48,28 @@ internal static class UrlBuilder
     public static string BuildLatestCurrentsUrl(Guid lineId)
         => GetFullUrl(module: GridInsight, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: Currents);
 
-    public static string BuildHeimdallDlrUrl(Guid lineId, Quantity quantity = Quantity.Current)
+    public static string BuildCurrentsUrl(Guid lineId, DateTimeOffset from, DateTimeOffset to)
+    {
+        var queryParams = new NameValueCollection()
+            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("o"))
+            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("o"));
+        return GetFullUrl(module: GridInsight, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: CurrentsHistorical, queryParams: queryParams);
+    }
+
+    public static string BuildConductorTemperaturesUrl(Guid lineId, DateTimeOffset from, DateTimeOffset to, string unitSystem = "metric")
+    {
+        var queryParams = new NameValueCollection()
+            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("o"))
+            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("o"))
+            .AddQueryParam("unit_system", unitSystem);
+        return GetFullUrl(module: GridInsight, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: ConductorTemperaturesHistorical, queryParams: queryParams);
+    }
+
+    public static string BuildLatestHeimdallDlrUrl(Guid lineId, Quantity quantity = Quantity.Current)
         => GetFullUrl(module: CapacityMonitoring, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: HeimdallDlr,
             queryParams: new NameValueCollection().AddQueryParam("quantity", quantity.ToQueryValue()));
 
-    public static string BuildHeimdallAarUrl(Guid lineId, Quantity quantity = Quantity.Current)
+    public static string BuildLatestHeimdallAarUrl(Guid lineId, Quantity quantity = Quantity.Current)
         => GetFullUrl(module: CapacityMonitoring, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: HeimdallAar,
             queryParams: new NameValueCollection().AddQueryParam("quantity", quantity.ToQueryValue()));
 
@@ -87,7 +106,7 @@ internal static class UrlBuilder
         => GetFullUrl(module: CapacityMonitoring, apiVersion: V1, resource: Facilities, resourceId: facilityId.ToString(), endpoint: CircuitRatingForecasts,
             queryParams: new NameValueCollection().AddQueryParam("quantity", quantity.ToQueryValue()));
 
-    public static string BuildCircuitRatingUrl(Guid facilityId, Quantity quantity = Quantity.Current)
+    public static string BuildLatestCircuitRatingUrl(Guid facilityId, Quantity quantity = Quantity.Current)
         => GetFullUrl(module: CapacityMonitoring, apiVersion: V1, resource: Facilities, resourceId: facilityId.ToString(), endpoint: CircuitRatingLatest,
             queryParams: new NameValueCollection().AddQueryParam("quantity", quantity.ToQueryValue()));
 


### PR DESCRIPTION
## Summary
* Add support for historical `Conductor temperature` and `Current`
* Rename client methods for latest endpoints to separate them from historical
