### PR TITLE
fix(dotnet): use explicit Z-suffixed UTC format for range endpoint timestamps

### DIFF
--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/UrlBuilder.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/UrlBuilder.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Specialized;
+using System.Globalization;
 using HeimdallPower.Api.Client.CapacityMonitoring;
 
 namespace HeimdallPower.Api.Client;
@@ -53,16 +54,16 @@ internal static class UrlBuilder
     public static string BuildCurrentsUrl(Guid lineId, DateTimeOffset from, DateTimeOffset to)
     {
         var queryParams = new NameValueCollection()
-            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
-            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"));
+            .AddQueryParam("from_timestamp", ToApiTimestamp(from))
+            .AddQueryParam("to_timestamp", ToApiTimestamp(to));
         return GetFullUrl(module: GridInsight, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: CurrentsHistorical, queryParams: queryParams);
     }
 
     public static string BuildConductorTemperaturesUrl(Guid lineId, DateTimeOffset from, DateTimeOffset to, string unitSystem = "metric")
     {
         var queryParams = new NameValueCollection()
-            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
-            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
+            .AddQueryParam("from_timestamp", ToApiTimestamp(from))
+            .AddQueryParam("to_timestamp", ToApiTimestamp(to))
             .AddQueryParam("unit_system", unitSystem);
         return GetFullUrl(module: GridInsight, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: ConductorTemperaturesHistorical, queryParams: queryParams);
     }
@@ -86,8 +87,8 @@ internal static class UrlBuilder
     public static string BuildHeimdallDlrsUrl(Guid lineId, DateTimeOffset from, DateTimeOffset to, Quantity quantity = Quantity.Current)
     {
         var queryParams = new NameValueCollection()
-            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
-            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
+            .AddQueryParam("from_timestamp", ToApiTimestamp(from))
+            .AddQueryParam("to_timestamp", ToApiTimestamp(to))
             .AddQueryParam("quantity", quantity.ToQueryValue());
         return GetFullUrl(module: CapacityMonitoring, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: HeimdallDlrs, queryParams: queryParams);
     }
@@ -95,8 +96,8 @@ internal static class UrlBuilder
     public static string BuildHeimdallAarsUrl(Guid lineId, DateTimeOffset from, DateTimeOffset to, Quantity quantity = Quantity.Current)
     {
         var queryParams = new NameValueCollection()
-            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
-            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
+            .AddQueryParam("from_timestamp", ToApiTimestamp(from))
+            .AddQueryParam("to_timestamp", ToApiTimestamp(to))
             .AddQueryParam("quantity", quantity.ToQueryValue());
         return GetFullUrl(module: CapacityMonitoring, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: HeimdallAars, queryParams: queryParams);
     }
@@ -115,8 +116,8 @@ internal static class UrlBuilder
     public static string BuildCircuitRatingsUrl(Guid facilityId, DateTimeOffset from, DateTimeOffset to, Quantity quantity = Quantity.Current)
     {
         var queryParams = new NameValueCollection()
-            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
-            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
+            .AddQueryParam("from_timestamp", ToApiTimestamp(from))
+            .AddQueryParam("to_timestamp", ToApiTimestamp(to))
             .AddQueryParam("quantity", quantity.ToQueryValue());
         return GetFullUrl(module: CapacityMonitoring, apiVersion: V1, resource: Facilities, resourceId: facilityId.ToString(), endpoint: CircuitRatings, queryParams: queryParams);
     }
@@ -127,7 +128,7 @@ internal static class UrlBuilder
             .AddQueryParam("unit_system", unitSystem);
 
         if (since.HasValue)
-            queryParams.AddQueryParam("since", since.Value.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"));
+            queryParams.AddQueryParam("since", ToApiTimestamp(since.Value));
 
         return GetFullUrl(module: GridInsight, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: IcingLatest, queryParams: queryParams);
     }
@@ -142,8 +143,8 @@ internal static class UrlBuilder
     public static string BuildIcingUrl(Guid lineId, DateTimeOffset from, DateTimeOffset to, string unitSystem = "metric")
     {
         var queryParams = new NameValueCollection()
-            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
-            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
+            .AddQueryParam("from_timestamp", ToApiTimestamp(from))
+            .AddQueryParam("to_timestamp", ToApiTimestamp(to))
             .AddQueryParam("unit_system", unitSystem);
         return GetFullUrl(module: GridInsight, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: Icing, queryParams: queryParams);
     }
@@ -154,8 +155,8 @@ internal static class UrlBuilder
     public static string BuildApparentPowersUrl(Guid lineId, DateTimeOffset from, DateTimeOffset to)
     {
         var queryParams = new NameValueCollection()
-            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
-            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"));
+            .AddQueryParam("from_timestamp", ToApiTimestamp(from))
+            .AddQueryParam("to_timestamp", ToApiTimestamp(to));
         return GetFullUrl(module: GridInsight, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: ApparentPower, queryParams: queryParams);
     }
 
@@ -173,11 +174,14 @@ internal static class UrlBuilder
     public static string BuildSagAndClearanceUrl(Guid lineId, DateTimeOffset from, DateTimeOffset to, string unitSystem = "metric")
     {
         var queryParams = new NameValueCollection()
-            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
-            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
+            .AddQueryParam("from_timestamp", ToApiTimestamp(from))
+            .AddQueryParam("to_timestamp", ToApiTimestamp(to))
             .AddQueryParam("unit_system", unitSystem);
         return GetFullUrl(module: GridInsight, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: SagAndClearance, queryParams: queryParams);
     }
+
+    private static string ToApiTimestamp(DateTimeOffset timestamp)
+        => timestamp.ToUniversalTime().ToString("yyyy-MM-dd'T'HH:mm:ss.fffffff'Z'", CultureInfo.InvariantCulture);
 
     private static string GetResourceUrl(string module, string apiVersion, string resource)
         => $"{module}/{apiVersion}/{resource}";

--- a/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/UrlBuilder.cs
+++ b/dotnet/HeimdallPower.Api.Client/HeimdallPower.Api.Client/UrlBuilder.cs
@@ -53,16 +53,16 @@ internal static class UrlBuilder
     public static string BuildCurrentsUrl(Guid lineId, DateTimeOffset from, DateTimeOffset to)
     {
         var queryParams = new NameValueCollection()
-            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("o"))
-            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("o"));
+            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
+            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"));
         return GetFullUrl(module: GridInsight, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: CurrentsHistorical, queryParams: queryParams);
     }
 
     public static string BuildConductorTemperaturesUrl(Guid lineId, DateTimeOffset from, DateTimeOffset to, string unitSystem = "metric")
     {
         var queryParams = new NameValueCollection()
-            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("o"))
-            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("o"))
+            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
+            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
             .AddQueryParam("unit_system", unitSystem);
         return GetFullUrl(module: GridInsight, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: ConductorTemperaturesHistorical, queryParams: queryParams);
     }
@@ -86,8 +86,8 @@ internal static class UrlBuilder
     public static string BuildHeimdallDlrsUrl(Guid lineId, DateTimeOffset from, DateTimeOffset to, Quantity quantity = Quantity.Current)
     {
         var queryParams = new NameValueCollection()
-            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("o"))
-            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("o"))
+            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
+            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
             .AddQueryParam("quantity", quantity.ToQueryValue());
         return GetFullUrl(module: CapacityMonitoring, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: HeimdallDlrs, queryParams: queryParams);
     }
@@ -95,8 +95,8 @@ internal static class UrlBuilder
     public static string BuildHeimdallAarsUrl(Guid lineId, DateTimeOffset from, DateTimeOffset to, Quantity quantity = Quantity.Current)
     {
         var queryParams = new NameValueCollection()
-            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("o"))
-            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("o"))
+            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
+            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
             .AddQueryParam("quantity", quantity.ToQueryValue());
         return GetFullUrl(module: CapacityMonitoring, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: HeimdallAars, queryParams: queryParams);
     }
@@ -115,8 +115,8 @@ internal static class UrlBuilder
     public static string BuildCircuitRatingsUrl(Guid facilityId, DateTimeOffset from, DateTimeOffset to, Quantity quantity = Quantity.Current)
     {
         var queryParams = new NameValueCollection()
-            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("o"))
-            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("o"))
+            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
+            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
             .AddQueryParam("quantity", quantity.ToQueryValue());
         return GetFullUrl(module: CapacityMonitoring, apiVersion: V1, resource: Facilities, resourceId: facilityId.ToString(), endpoint: CircuitRatings, queryParams: queryParams);
     }
@@ -127,7 +127,7 @@ internal static class UrlBuilder
             .AddQueryParam("unit_system", unitSystem);
 
         if (since.HasValue)
-            queryParams.AddQueryParam("since", since.Value.ToUniversalTime().ToString("o"));
+            queryParams.AddQueryParam("since", since.Value.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"));
 
         return GetFullUrl(module: GridInsight, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: IcingLatest, queryParams: queryParams);
     }
@@ -154,8 +154,8 @@ internal static class UrlBuilder
     public static string BuildApparentPowersUrl(Guid lineId, DateTimeOffset from, DateTimeOffset to)
     {
         var queryParams = new NameValueCollection()
-            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("o"))
-            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("o"));
+            .AddQueryParam("from_timestamp", from.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"))
+            .AddQueryParam("to_timestamp", to.ToUniversalTime().ToString("yyyy-MM-ddTHH:mm:ss.fffffffZ"));
         return GetFullUrl(module: GridInsight, apiVersion: V1, resource: Lines, resourceId: lineId.ToString(), endpoint: ApparentPower, queryParams: queryParams);
     }
 

--- a/dotnet/examples/Api.Client.Examples/Program.cs
+++ b/dotnet/examples/Api.Client.Examples/Program.cs
@@ -26,19 +26,27 @@ var to = DateTimeOffset.Now;
 
 // Fetch Aggregated Measurements data
 var latestCurrent = await api.GetLatestCurrentAsync(line.Id);
+var currents = await api.GetCurrentsAsync(line.Id, from, to);
+
+Console.WriteLine($"- Current: {latestCurrent.Current.Value} {latestCurrent.Unit} at {latestCurrent.Current.Timestamp}");
+Console.WriteLine($"- Currents from {from} to {to} - First value: {currents.Currents.FirstOrDefault()?.Value} {currents.Unit} at {currents.Currents.FirstOrDefault()?.Timestamp}, " +
+                  $"Last value: {currents.Currents.LastOrDefault()?.Value} {currents.Unit} at {currents.Currents.LastOrDefault()?.Timestamp}");
+
 var latestConductorTemperature = await api.GetLatestConductorTemperatureAsync(line.Id);
+var conductorTemperatures = await api.GetConductorTemperaturesAsync(line.Id, from, to);
+
+Console.WriteLine($"- Conductor Temperature: {latestConductorTemperature.ConductorTemperature.Max} {latestConductorTemperature.Unit} at {latestConductorTemperature.ConductorTemperature.Timestamp}");
+Console.WriteLine($"- Conductor Temperatures from {from} to {to} - First max value: {conductorTemperatures.ConductorTemperatures.FirstOrDefault()?.Max} {conductorTemperatures.Unit} at {conductorTemperatures.ConductorTemperatures.FirstOrDefault()?.Timestamp}, " +
+                  $" Last max value: {conductorTemperatures.ConductorTemperatures.LastOrDefault()?.Max} {conductorTemperatures.Unit} at {conductorTemperatures.ConductorTemperatures.LastOrDefault()?.Timestamp}");
 
 var latestIcing = await api.GetLatestIcingAsync(line.Id);
 var icings = await api.GetIcingsAsync(line.Id, from, to);
 
-var latestSagAndClearance = await api.GetLatestSagAndClearanceAsync(line.Id);
-var sagAndClearances = await api.GetSagAndClearancesAsync(line.Id, from, to);
-
-Console.WriteLine($"- Current: {latestCurrent.Current.Value} {latestCurrent.Unit} at {latestCurrent.Current.Timestamp}");
-Console.WriteLine($"- Conductor Temperature: {latestConductorTemperature.ConductorTemperature.Max} {latestConductorTemperature.Unit} at {latestConductorTemperature.ConductorTemperature.Timestamp}");
-
 Console.WriteLine($"- Icing: Maximum Ice weight: {latestIcing.Icing.Max.IceWeight.Value} at span phase: {latestIcing.Icing.Max.IceWeight.SpanPhaseId}");
 Console.WriteLine($"- Icing from {from} to {to} - Max Ice weight: {icings.Icing.Max.IceWeight.Value} {icings.Icing.Max.IceWeight.Unit} at span phase: {icings.Icing.Max.IceWeight.SpanPhaseId}");
+
+var latestSagAndClearance = await api.GetLatestSagAndClearanceAsync(line.Id);
+var sagAndClearances = await api.GetSagAndClearancesAsync(line.Id, from, to);
 
 Console.WriteLine($"- Sag and Clearance: Maximum sag: {latestSagAndClearance.SagAndClearance.MaxSag.Value} {latestSagAndClearance.SagAndClearance.MaxSag.Unit} at span phase: {latestSagAndClearance.SagAndClearance.MaxSag.SpanPhaseId}");
 Console.WriteLine($"- Sag and Clearance from {from} to {to} - Max Sag: {sagAndClearances.SagAndClearance.MaxSag.Value} - Min Clearance: {sagAndClearances.SagAndClearance.MinClearance?.Value}");


### PR DESCRIPTION
**Changes:**
`DateTimeOffset.ToString("o")` emits a "+00:00" offset rather than a"Z" suffix, which the API does not accept for from/to timestamps.

Format all range query params (currents, conductor temperatures, Heimdall DLRs/AARs, circuit ratings, apparent power) and thelatest-icing `since` param as `yyyy-MM-ddTHH:mm:ss.fffffffZ`.