### PR TITLE
ci: POWER-5121 use NuGet trusted publishing via OIDC

### DIFF
--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -8,6 +8,8 @@ jobs:
   publish:
     name: Publish to NuGet
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write # Enable GitHub OIDC token issuance for NuGet Trusted Publishing
     defaults:
       run:
         working-directory: dotnet
@@ -42,11 +44,15 @@ jobs:
           dotnet pack HeimdallPower.Api.Client/HeimdallPower.Api.Client/HeimdallPower.Api.Client.csproj --configuration Release --no-build -o out /p:PackageVersion=$VERSION
           dotnet pack HeimdallPower.Api.Client/HeimdallPower.Api.Client.Extensions/HeimdallPower.Api.Client.Extensions.csproj --configuration Release --no-build -o out /p:PackageVersion=$VERSION
 
+      - name: NuGet login (OIDC -> short-lived API key)
+        uses: NuGet/login@v1
+        id: login
+        with:
+          user: ${{ vars.NUGET_USER }}
+
       - name: Publish the package to nuget.org
         run: |
           for file in out/*.nupkg; do
             echo "Publishing $file"
-            dotnet nuget push "$file" -k $NUGET_AUTH_TOKEN -s https://api.nuget.org/v3/index.json --skip-duplicate
+            dotnet nuget push "$file" --api-key ${{ steps.login.outputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
           done
-        env:
-          NUGET_AUTH_TOKEN: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -9,6 +9,7 @@ jobs:
     name: Publish to NuGet
     runs-on: ubuntu-latest
     permissions:
+      contents: read # Allow actions/checkout to fetch the repository
       id-token: write # Enable GitHub OIDC token issuance for NuGet Trusted Publishing
     defaults:
       run:
@@ -54,5 +55,5 @@ jobs:
         run: |
           for file in out/*.nupkg; do
             echo "Publishing $file"
-            dotnet nuget push "$file" --api-key ${{ steps.login.outputs.NUGET_API_KEY }} -s https://api.nuget.org/v3/index.json --skip-duplicate
+            dotnet nuget push "$file" --api-key "${{ steps.login.outputs.NUGET_API_KEY }}" -s https://api.nuget.org/v3/index.json --skip-duplicate
           done


### PR DESCRIPTION
# Summary

Switches the NuGet publish workflow from a long-lived NUGET_API_KEY secret to trusted publishing over GitHub OIDC. Adds id-token: write on the publish job and a NuGet/login@v1 step that mints a short-lived API key at push time; the nuget.org username is read from the new NUGET_USER repo variable. A matching trusted-publishing policy is already configured on nuget.org, and the NUGET_API_KEY secret can be removed once this is merged and verified.

## Jira

Ticket: POWER-5121

## AI usage (required)

- [ ] No AI used
- [ ] Observation (no repository artifact)
- [ ] Proposal (AI-generated content, human-constructed PR)
- [x] Assisted execution (AI-created commits or opened PR)
