### PR TITLE
feat(python): POWER-5106 publish Python SDK to PyPI via trusted publishing

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -14,6 +14,7 @@ jobs:
 
     permissions:
       contents: write # Required to upload release artifacts
+      id-token: write # Enable GitHub OIDC token issuance for PyPI Trusted Publishing
 
     steps:
       - name: Checkout repository
@@ -47,6 +48,11 @@ jobs:
 
       - name: Build package
         run: poetry build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python/dist
 
       - name: Upload dist artifacts to GitHub Release
         uses: softprops/action-gh-release@v2

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,7 +51,7 @@ ci: add conventional commits PR title validation
 - Contributions should be made as pull requests into `main`.
 - Releases are managed using GitHub Releases.
 - Tags must follow the format: `v<MAJOR>.<MINOR>.<PATCH>` (e.g., `v1.2.3`)
-- A GitHub Release must be published for the package to be built and pushed to NuGet
+- A GitHub Release must be published for the packages to be built and published: the .NET package is pushed to [NuGet](https://www.nuget.org/) and the Python package to [PyPI](https://pypi.org/project/heimdallpower-api-client/) (both via trusted publishing / OIDC, no stored API tokens)
 - The `v` prefix is automatically stripped when packaging
 
 ---

--- a/python/README.md
+++ b/python/README.md
@@ -18,10 +18,16 @@ poetry install
 
 ### Installing the SDK
 
-The package can be downloaded and installed using the GitHub release artifacts:
+The package is published to [PyPI](https://pypi.org/project/heimdallpower-api-client/):
 
 ```bash
-pip install https://github.com/heimdallpower/api-sdk/releases/download/v1.2.3/heimdall_api_client-1.2.3-py3-none-any.whl
+pip install heimdallpower-api-client
+```
+
+Alternatively, it can be downloaded and installed using the GitHub release artifacts:
+
+```bash
+pip install https://github.com/heimdallpower/api-sdk/releases/download/v1.2.3/heimdallpower_api_client-1.2.3-py3-none-any.whl
 ```
 
 > Replace the version and filename with the latest from [Releases](https://github.com/heimdallpower/api-sdk/releases)

--- a/python/heimdall_api_client/client.py
+++ b/python/heimdall_api_client/client.py
@@ -4,6 +4,7 @@ import datetime
 import logging
 import time
 from collections.abc import Callable
+from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, TypeVar
 from uuid import UUID
 
@@ -57,6 +58,12 @@ if TYPE_CHECKING:
 
 
 _MAX_RETRY_ATTEMPTS = 3
+
+try:
+    _SDK_VERSION = version("heimdallpower-api-client")
+except PackageNotFoundError:
+    # Running from source (e.g. a repo checkout) rather than an installed distribution
+    _SDK_VERSION = "0.0.0"
 
 
 class HeimdallApiClient:
@@ -144,7 +151,7 @@ class HeimdallApiClient:
 
         default_metadata = {
             "x-client-name": "python-sdk",
-            "x-client-version": "0.0.0",
+            "x-client-version": _SDK_VERSION,
         }
 
         # Ensure user values override the defaults

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "heimdall-api-client"
+name = "heimdallpower-api-client"
 version = "0.1.0"
 description = "Python SDK for interacting with the Heimdall Power External API"
 authors = [

--- a/python/tests/unit/test_client_metadata.py
+++ b/python/tests/unit/test_client_metadata.py
@@ -1,0 +1,41 @@
+"""
+Unit tests for the default client metadata headers sent by HeimdallApiClient.
+
+Covers:
+- x-client-version reflects the installed distribution version (not a hardcoded value)
+- Fallback to "0.0.0" when the distribution is not installed (running from source)
+- User-supplied client_metadata overrides the defaults
+"""
+
+from importlib.metadata import PackageNotFoundError
+
+from heimdall_api_client.client import _SDK_VERSION, HeimdallApiClient
+
+
+def _make_client(**kwargs) -> HeimdallApiClient:
+    return HeimdallApiClient(client_id="fake-id", client_secret="fake-secret", **kwargs)
+
+
+class TestClientMetadata:
+    def test_default_metadata_uses_sdk_version(self):
+        client = _make_client()
+
+        assert client.client_metadata["x-client-name"] == "python-sdk"
+        assert client.client_metadata["x-client-version"] == _SDK_VERSION
+
+    def test_sdk_version_matches_installed_distribution(self):
+        from importlib.metadata import version
+
+        try:
+            expected = version("heimdallpower-api-client")
+        except PackageNotFoundError:
+            expected = "0.0.0"
+
+        assert _SDK_VERSION == expected
+
+    def test_user_metadata_overrides_defaults(self):
+        client = _make_client(client_metadata={"x-client-version": "9.9.9", "x-custom": "abc"})
+
+        assert client.client_metadata["x-client-version"] == "9.9.9"
+        assert client.client_metadata["x-custom"] == "abc"
+        assert client.client_metadata["x-client-name"] == "python-sdk"


### PR DESCRIPTION
# Summary

Adds a PyPI publish step to the Python release workflow using OIDC trusted publishing (pypa/gh-action-pypi-publish), mirroring the NuGet setup from POWER-5121 — no stored API token, and the GitHub Release wheel upload is kept for backward compatibility. Renames the distribution to heimdallpower-api-client to match the pending publisher under the heimdallpower PyPI org (the import package heimdall_api_client is unchanged). Also fixes the x-client-version header to resolve the installed distribution version via importlib.metadata instead of a hardcoded 0.0.0.

## Jira

Ticket: POWER-5106

## AI usage (required)

- [ ] No AI used
- [ ] Observation (no repository artifact)
- [ ] Proposal (AI-generated content, human-constructed PR)
- [x] Assisted execution (AI-created commits or opened PR)
