### PR TITLE
fix(python): POWER-5106 add readme and project urls to PyPI metadata

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,6 +1,6 @@
 # Heimdall API SDK for Python
 
-This folder contains the Python SDK for accessing the [Heimdall Power External API](https://developer.heimdallcloud.com/docs/welcome).
+The official Python SDK for accessing the [Heimdall Power External API](https://developer.heimdallcloud.com/docs/welcome).
 
 ## Getting Started
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,6 +2,7 @@
 name = "heimdallpower-api-client"
 version = "0.1.0"
 description = "Python SDK for interacting with the Heimdall Power External API"
+readme = "README.md"
 authors = [
   { name = "Heimdall Power", email = "software-developers@heimdallpower.com" }
 ]
@@ -14,6 +15,12 @@ dependencies = [
   "attrs (>=25.3.0,<26.0.0)",
   "python-dateutil (>=2.9.0.post0,<3.0.0)"
 ]
+
+[project.urls]
+Homepage = "https://developer.heimdallcloud.com"
+Documentation = "https://developer.heimdallcloud.com/docs/welcome"
+Repository = "https://github.com/heimdallpower/api-sdk"
+Changelog = "https://github.com/heimdallpower/api-sdk/releases"
 
 [tool.poetry.group.dev.dependencies]
 ruff = "^0.15.20"


### PR DESCRIPTION
# Summary

Fixes the empty project description on https://pypi.org/project/heimdallpower-api-client/ by declaring python/README.md as the package readme in pyproject.toml, and adds Homepage/Documentation/Repository/Changelog project URLs for the PyPI sidebar. Also rewords the README opening line so it reads naturally as a PyPI landing page. Verified locally: the built wheel's METADATA embeds the readme (text/markdown) and all four Project-URL entries; poetry check --lock passes.

## Jira

Ticket: POWER-5106

## AI usage (required)

- [ ] No AI used
- [ ] Observation (no repository artifact)
- [ ] Proposal (AI-generated content, human-constructed PR)
- [x] Assisted execution (AI-created commits or opened PR)
